### PR TITLE
improve Caddy & Compose files for easier dev setups

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,6 +1,6 @@
 # Backend
 
-api.smd-karlsruhe.de {
+api.{$DOMAIN_LONG} {
     reverse_proxy backend:8090 {
         # X-Forwarded-For & X-Forwarded-Proto are set by default
         header_up X-Real-IP {remote_host}
@@ -10,7 +10,7 @@ api.smd-karlsruhe.de {
 
 # Frontend
 
-smd-karlsruhe.de {
+{$DOMAIN_LONG} {
     reverse_proxy frontend:3000 {
         # X-Forwarded-For & X-Forwarded-Proto are set by default
         header_up X-Real-IP {remote_host}
@@ -18,10 +18,10 @@ smd-karlsruhe.de {
 }
 
 # redirections
-smd-ka.de, www.smd-ka.de, www.smd-karlsruhe.de {
-    redir https://smd-karlsruhe.de{uri}
+{$DOMAIN_SHORT}, www.{$DOMAIN_SHORT}, www.{$DOMAIN_LONG} {
+    redir https://{$DOMAIN_LONG}{uri}
 }
 
-api.smd-ka.de {
-    redir https://api.smd-karlsruhe.de{uri}
+api.{$DOMAIN_SHORT} {
+    redir https://api.{$DOMAIN_LONG}{uri}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,8 @@ services:
     container_name: caddy
     image: docker.io/library/caddy:2.8
     environment:
-      DOMAIN_LONG: smd-karlsruhe.de
-      DOMAIN_SHORT: smd-ka.de
+      DOMAIN_LONG: ${DOMAIN_LONG:-smd-karlsruhe.de}
+      DOMAIN_SHORT: ${DOMAIN_SHORT:-smd-ka.de}
     ports:
       - 80:80
       - 443:443

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ services:
   backend:
     container_name: backend
     image: ghcr.io/smd-ka/smd-ka/backend:main
+    build:
+      context: ./backend
+      dockerfile: ./Dockerfile
     volumes:
       - ./backend/pb_data:/pb/pb_data
       - ./backend/pb_migrations:/pb/pb_migrations
@@ -16,6 +19,9 @@ services:
   frontend:
     container_name: frontend
     image: ghcr.io/smd-ka/smd-ka/frontend:main
+    build:
+      context: ./frontend
+      dockerfile: ./Dockerfile
     restart: always
     networks:
       - smd_ka_network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,9 @@ services:
   caddy:
     container_name: caddy
     image: docker.io/library/caddy:2.8
+    environment:
+      DOMAIN_LONG: smd-karlsruhe.de
+      DOMAIN_SHORT: smd-ka.de
     ports:
       - 80:80
       - 443:443


### PR DESCRIPTION
for easier setting up dev environments:

- use env vars for caddy domains (now overwritable using a `.env` file)
- add build instructions to backend & frontend images into docker-compose.yml

I have tested those "on the field" while working on #34. When not given explicit intruction to build, docker compose should divert to downloading the images from GitHub.
And Caddy (or rather Docker Compose) should default the DOMAIN_LONG & DOMAIN_SHORT variables to smd-karlsruhe.de & smd-ka.de respectively.