### PR TITLE
Calendar category update

### DIFF
--- a/backend/migrations/1749125311_updated_calendar.go
+++ b/backend/migrations/1749125311_updated_calendar.go
@@ -1,0 +1,65 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+func init() {
+	m.Register(func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("vcqdyzm1pq5e01u")
+		if err != nil {
+			return err
+		}
+
+		// update field
+		if err := collection.Fields.AddMarshaledJSONAt(7, []byte(`{
+			"hidden": false,
+			"id": "nf40y9gd",
+			"maxSelect": 1,
+			"name": "category",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "select",
+			"values": [
+				"erstsemesteraktion",
+				"kingscafe",
+				"smd_abend",
+				"MIT",
+				"lecture_talk"
+			]
+		}`)); err != nil {
+			return err
+		}
+
+		return app.Save(collection)
+	}, func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("vcqdyzm1pq5e01u")
+		if err != nil {
+			return err
+		}
+
+		// update field
+		if err := collection.Fields.AddMarshaledJSONAt(7, []byte(`{
+			"hidden": false,
+			"id": "nf40y9gd",
+			"maxSelect": 1,
+			"name": "category",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "select",
+			"values": [
+				"erstsemesteraktion",
+				"kingscafe",
+				"smd_abend",
+				"MIT"
+			]
+		}`)); err != nil {
+			return err
+		}
+
+		return app.Save(collection)
+	})
+}

--- a/backend/migrations/1749126740_updated_calendar.go
+++ b/backend/migrations/1749126740_updated_calendar.go
@@ -1,0 +1,67 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+func init() {
+	m.Register(func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("vcqdyzm1pq5e01u")
+		if err != nil {
+			return err
+		}
+
+		// update field
+		if err := collection.Fields.AddMarshaledJSONAt(7, []byte(`{
+			"hidden": false,
+			"id": "nf40y9gd",
+			"maxSelect": 1,
+			"name": "category",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "select",
+			"values": [
+				"erstsemesteraktion",
+				"kingscafe",
+				"smd_abend",
+				"MIT",
+				"lecture_talk",
+				"german_bible_study"
+			]
+		}`)); err != nil {
+			return err
+		}
+
+		return app.Save(collection)
+	}, func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("vcqdyzm1pq5e01u")
+		if err != nil {
+			return err
+		}
+
+		// update field
+		if err := collection.Fields.AddMarshaledJSONAt(7, []byte(`{
+			"hidden": false,
+			"id": "nf40y9gd",
+			"maxSelect": 1,
+			"name": "category",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "select",
+			"values": [
+				"erstsemesteraktion",
+				"kingscafe",
+				"smd_abend",
+				"MIT",
+				"lecture_talk",
+			]
+		}`)); err != nil {
+			return err
+		}
+
+		return app.Save(collection)
+	})
+}

--- a/frontend/src/routes/events/kalender/+page.ts
+++ b/frontend/src/routes/events/kalender/+page.ts
@@ -8,7 +8,7 @@ export const load: PageLoad = async () => {
 		const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).toISOString();
 		const records = await pb.collection('calendar').getFullList({
 			sort: '+start_date_time',
-			filter: `start_date_time >= "${startOfToday}" && category!='kingscafe'`
+			filter: `start_date_time >= "${startOfToday}" && category!='german_bible_study'`
 		});
 		calendarEvents.set(records);
 		return { events: records };

--- a/frontend/src/routes/events/kalender/[slug]/+page.svelte
+++ b/frontend/src/routes/events/kalender/[slug]/+page.svelte
@@ -95,7 +95,7 @@
 				{/if}
 
 				{#if data.event.speaker}
-					<div>Referent: {data.event.speaker}</div>
+					<div>Referent/Referentin: {data.event.speaker}</div>
 				{/if}
 			</div>
 		</section>

--- a/frontend/src/routes/events/kalender/[slug]/+page.ts
+++ b/frontend/src/routes/events/kalender/[slug]/+page.ts
@@ -23,6 +23,16 @@ export const _categoryToDisplayName = (category: string) => {
 	switch (category) {
 		case 'smd_abend':
 			return 'SMD-Abend';
+		case 'lecture_talk':
+			return 'Hörsaalvortrag';
+		case 'kingscafe':
+			return 'King’s Café';
+		case 'MIT':
+			return 'Mitarbeiter-Treffen';
+		case 'erstsemesteraktion':
+			return 'Erstsemesteraktion';
+		case 'german_bible_study':
+			return 'Deutschkurs mit der Bibel';
 		default:
 			return '';
 	}

--- a/frontend/src/routes/intern/kalender/+page.svelte
+++ b/frontend/src/routes/intern/kalender/+page.svelte
@@ -83,6 +83,10 @@
 			<section
 				class="overflow-y-auto overflow-x-hidden rounded-md bg-white p-4 shadow-md lg:h-[82svh]"
 			>
+				<p class="rounded-md bg-gray-200 text-center">
+					Übersetzung wird aktuell nur auf der Kings-Café-Seite angezeigt! Übersetzung ist aber auch
+					für die Hauptseite geplant.
+				</p>
 				{#if !shownEvent}
 					<AddEventForm />
 				{:else}

--- a/frontend/src/routes/intern/kalender/addEventForm.svelte
+++ b/frontend/src/routes/intern/kalender/addEventForm.svelte
@@ -67,7 +67,7 @@
 		<TextInput name="title" label="Titel*" disabled={loading} required />
 		<TextInput name="title_en" label="Titel (Englisch)" disabled={loading} required />
 
-		<CalendarCategorySelect />
+		<CalendarCategorySelect {loading} />
 
 		<div>
 			<DateTimeInput value={undefined} required name="start_date_time" disabled={loading}>

--- a/frontend/src/routes/intern/kalender/addEventForm.svelte
+++ b/frontend/src/routes/intern/kalender/addEventForm.svelte
@@ -9,6 +9,7 @@
 	import UrlInput from '$lib/components/forms/UrlInput.svelte';
 	import { goto } from '$app/navigation';
 	import { _handleDates } from './+page';
+	import CalendarCategorySelect from './calendarCategorySelect.svelte';
 
 	let src = '';
 	let image: undefined | File = undefined;
@@ -66,13 +67,8 @@
 		<TextInput name="title" label="Titel*" disabled={loading} required />
 		<TextInput name="title_en" label="Titel (Englisch)" disabled={loading} required />
 
-		<select name="category" disabled={loading} class="w-full rounded-md border-2 py-3">
-			<option value="" disabled selected>Kategorie, falls vorhanden</option>
-			<option value="smd_abend">SMD-Abend</option>
-			<option value="erstsemesteraktion">Erstsemesteraktion</option>
-			<option value="kingscafe">Kings-Café</option>
-			<option value="MIT">MIT</option>
-		</select>
+		<CalendarCategorySelect />
+
 		<div>
 			<DateTimeInput value={undefined} required name="start_date_time" disabled={loading}>
 				Datum und Uhrzeit (Start)*

--- a/frontend/src/routes/intern/kalender/calendarCategorySelect.svelte
+++ b/frontend/src/routes/intern/kalender/calendarCategorySelect.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	export let category: string | undefined = undefined;
+	export let category: string | undefined = '';
 	export let loading = false;
 </script>
 

--- a/frontend/src/routes/intern/kalender/calendarCategorySelect.svelte
+++ b/frontend/src/routes/intern/kalender/calendarCategorySelect.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	export let category: string | undefined = undefined;
+	export let loading = false;
+</script>
+
+<select name="category" value={category} disabled={loading} class="w-full rounded-md border-2 py-3">
+	<option value="" disabled selected>Kategorie, falls vorhanden</option>
+	<option value="smd_abend">SMD-Abend</option>
+	<option value="erstsemesteraktion">Erstsemesteraktion</option>
+	<option value="kingscafe">Kings-Café</option>
+	<option value="MIT">MIT</option>
+	<option value="lecture_talk">Hörsaalvortrag</option>
+	<option value="">sonstige/keine vorhanden</option>
+</select>

--- a/frontend/src/routes/intern/kalender/editEventForm.svelte
+++ b/frontend/src/routes/intern/kalender/editEventForm.svelte
@@ -14,6 +14,7 @@
 		faTrash
 	} from '@fortawesome/free-solid-svg-icons';
 	import loadingSpinner from '$lib/assets/loading_spinner_white.gif';
+	import CalendarCategorySelect from './calendarCategorySelect.svelte';
 	export let shownEvent;
 	export let loading = false;
 	export let updated = false;
@@ -127,20 +128,9 @@
 	/>
 	<TextInput value={shownEvent.speaker} name="speaker" label="Referent" />
 
-	<select
-		name="category"
-		value={shownEvent.category}
-		disabled={loading}
-		class="w-full rounded-md border-2 py-3"
-	>
-		<option value="" disabled selected>Kategorie, falls vorhanden</option>
-		<option value="smd_abend">SMD-Abend</option>
-		<option value="erstsemesteraktion">Erstsemesteraktion</option>
-		<option value="kingscafe">Kings-Café</option>
-		<option value="MIT">MIT</option>
-	</select>
+	<CalendarCategorySelect {loading} category={shownEvent.category} />
 
-	<div class="col-span-full">
+	<div class="col-span-full grid gap-4">
 		<TextArea
 			value={shownEvent.description}
 			name="description"


### PR DESCRIPTION
- add `lecutre_talk` category for calendar events
- show event category for more categories on detailed view of event
- add comment about translation 
- make kings cafe events visible in list view
- only events of kings cafe not german bible studies should be displayed. Therefore added `german_bible_study` category

after merge events might need to be reconfigured for the bible study