### PR TITLE
add docker setup for PHP server for dokuwiki

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -37,6 +37,15 @@ api.{$DOMAIN_SHORT} {
    reverse_proxy kings_cafe:3000
 }
 
+# DokuWiki
+# TO BE CHANGED TO wiki.smd-karlsruhe.de
+dokuwiki.{$DOMAIN_LONG} {
+    reverse_proxy dokuwiki:80 {
+        # X-Forwarded-For & X-Forwarded-Proto are set by default
+        header_up X-Real-IP {remote_host}
+    }
+}
+
 
 # Authentik
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,15 @@ services:
       - default
     restart: always
 
+  dokuwiki:
+    container_name: dokuwiki
+    image: php:7-apache-bullseye
+    volumes:
+      - 'dokuwiki_config:/var/www/html'
+    networks:
+      - default
+    restart: always
+
   caddy:
     container_name: caddy
     image: docker.io/library/caddy:2.8


### PR DESCRIPTION
After Deploy Plugins and Data needs to be migrated manually
For now this shall live under dokuwiki.smd-karlsruhe.de until everything is operational.
Once that is done the caddy setup needs to be changed to wiki.smd-karlsruhe.de
TTL of DNS Record is already reduced to 600s
Probably the links from the intern area should be changed in a way that they automatically log you in
