### PR TITLE
frontend/kontakt: remove absolute class to make loadingSpinner visible

### DIFF
--- a/frontend/src/routes/about/kontakt/+page.svelte
+++ b/frontend/src/routes/about/kontakt/+page.svelte
@@ -145,7 +145,7 @@
 
 			<button disabled={loading} type="submit" class="w-fit bg-black p-4 text-white">
 				{#if loading}
-					<img class="absolute left-2 h-8" src={loadingSpinner} alt="loading" />
+					<img class="left-2 h-8" src={loadingSpinner} alt="loading" />
 				{/if}
 				Abschicken</button
 			>


### PR DESCRIPTION
while working on #157, found out that spinner was not visible (at least on Firefox). Tested by doing the following:
- open "Kontakt" page on Firefox
- open Dev Tools with CTRL+SHIFT+i
- in Dev Tools navigate to Network tab, click on "No Throttling" on the right & select "GPRS"
- fill out "Kontakt" formular & submit it

Without this PR, the spinner is not visible while the form is submitted. With this PR, it is.