### PR TITLE
add support for (multilingual) iCalendar exports

### DIFF
--- a/frontend/src/routes/events/kalender/events.ics/+server.ts
+++ b/frontend/src/routes/events/kalender/events.ics/+server.ts
@@ -1,0 +1,215 @@
+import type { RequestHandler } from './$types';
+import { pb } from '$lib/pocketbase';
+import { _imgSrc } from '../+page';
+import { getImageMimeType } from '../image-mime';
+
+const BASE_URL = 'https://smd-karlsruhe.de';
+
+// DO NOT CHANGE THESE VALUES
+// changing THESE may confuse calendar clients
+const IMPLEMENTATION_DOMAIN = 'smd-karlsruhe.de';
+const IMPLEMENTATION_ID = '20251017-implementation';
+
+type RecordLike = {
+    collectionId: string;
+    collectionName: string;
+    id: string;
+    title?: string;
+    title_en?: string;
+    description?: string;
+    description_en?: string;
+    image: string;
+    /** ISO-ish string (without "T" between date & time) */
+    start_date_time: string;
+    /** ISO-ish string (without "T" between date & time) */
+    end_date_time?: string;
+    location?: string;
+    location_url?: string;
+    speaker?: string;
+    /** ISO-ish string (without "T" between date & time) */
+    created: string;
+    /** ISO-ish string (without "T" between date & time) */
+    updated: string;
+    category: string;
+    [k: string]: any;
+};
+
+async function retrieveEvents(): Promise<RecordLike[]> {
+    return await pb.collection('calendar').getFullList({
+        sort: '+start_date_time',
+        filter: `category!='german_bible_study'`
+    });
+}
+
+function pad(num: number, size: number = 2): string {
+    return String(num).padStart(size, '0');
+}
+
+function formatICSDate(d: Date): string {
+    // RFC 5545: YYYYMMDDTHHMMSSZ (for UTC)
+    return (
+        d.getUTCFullYear().toString() +
+        pad(d.getUTCMonth() + 1) +
+        pad(d.getUTCDate()) +
+        'T' +
+        pad(d.getUTCHours()) +
+        pad(d.getUTCMinutes()) +
+        pad(d.getUTCSeconds()) +
+        'Z'
+    );
+}
+
+function escapeICSText(text: string): string {
+    if (!text) return '';
+    // RFC 5545: escape backslashes, semicolons, commas and newlines
+    return text
+        .trim()
+        .replace(/\\/g, '\\\\')
+        .replace(/;/g, '\\;')
+        .replace(/,/g, '\\,')
+        .replace(/\r\n/g, '\\n')
+        .replace(/\n/g, '\\n');
+}
+
+function foldICSLine(line: string, maxLen: number = 75): string[] {
+    // RFC 5545: fold long lines by inserting CRLF + single space on continuations
+    const out: string[] = [];
+    let i = 0;
+    while (i < line.length) {
+        const chunk = line.slice(i, i + maxLen);
+        out.push(chunk);
+        i += maxLen;
+    }
+    if (out.length <= 1) return out;
+    return [out[0], ...out.slice(1).map((l) => ' ' + l)];
+}
+
+type OptionalValue = string | null | undefined;
+type DictValues = {
+    [key: string]: OptionalValue;
+};
+
+function stringProperty(property: string, value: string): string {
+    return `${property}:${escapeICSText(value)}`;
+}
+
+function optionalProperty(property: string, value: OptionalValue): string[] {
+    return value ? [stringProperty(property, value)] : [];
+}
+
+function dateProperty(property: string, value: string): string {
+    const dt = new Date(value);
+    if (isNaN(dt.getTime())) throw new Error(`could not parse datetime value for property ${property}: ${value}`);
+    return `${property}:${formatICSDate(dt)}`;
+}
+
+function languageProperty(
+    property: string,
+    values: DictValues,
+    default_value: OptionalValue = undefined,
+): string[] {
+    const ret: string[] = [];
+    for (const [lang, val] of Object.entries(values))
+        if (val)
+            ret.push(`${property};LANGUAGE=${lang}:${escapeICSText(val.trim())}`);
+    ret.reverse()
+    if (ret.length <= 0 && default_value)
+        ret.push(stringProperty(property, default_value));
+    return ret;
+}
+
+function renderDescription(description: OptionalValue, properties: DictValues): string {
+    const descSections: string[] = [];
+    if (description) descSections.push(description);
+    const descProps: string[] = [];
+    for (const [name, val] of Object.entries(properties))
+        if (val)
+            descProps.push(`${name}: ${val.trim()}`);
+    if (descProps.length <= 0) descSections.push(descProps.join('\n'));
+    return descSections.join('\n\n');
+}
+
+/**
+ * Return only the VEVENT lines for the given record.
+ */
+function recordToVeventLines(record: RecordLike): string[] {
+    let imageSrc = _imgSrc(record.image, record.id, record.collectionId, record.collectionName, record.category);
+    if (imageSrc.startsWith("/")) imageSrc = `${BASE_URL}${imageSrc}`;
+
+    const rawLines: string[] = [
+        'BEGIN:VEVENT',
+        // == RFC 5545 (https://datatracker.ietf.org/doc/html/rfc5545)
+        // 3.8.1. Descriptive Component Properties
+        ...optionalProperty("CATEGORIES", record.category),
+        ...languageProperty("DESCRIPTION", {
+            de: renderDescription(record.description, {
+                Speaker: record.speaker,
+                "Link zum Standort": record.location_url,
+            }),
+            en: renderDescription(record.description_en, {
+                Speaker: record.speaker,
+                "Link to Location": record.location_url,
+            }),
+        }),
+        ...optionalProperty("LOCATION", record.location || record.location_url),
+        ...languageProperty("SUMMARY", { de: record.title, en: record.title_en }, `Event ${record.id}`),
+        // 3.8.2. Date and Time Component Properties
+        dateProperty("DTSTART", record.start_date_time),
+        dateProperty("DTEND", record.end_date_time || record.start_date_time),
+        // 3.8.4. Relationship Component Properties
+        stringProperty("URL", `${BASE_URL}/events/kalender/${record.id}`),
+        stringProperty("UID", `${IMPLEMENTATION_ID}/${record.collectionId}/${record.id}@${IMPLEMENTATION_DOMAIN}`),
+        // 3.8.7. Change Management Component Properties
+        dateProperty("CREATED", record.created),
+        dateProperty("DTSTAMP", record.updated),
+        dateProperty("LAST-MODIFIED", record.updated),
+        // == RFC 7986 (https://datatracker.ietf.org/doc/html/rfc7986)
+        `IMAGE:VALUE=URI;DISPLAY=BADGE;FMTTYPE=${getImageMimeType(record.image)}:${imageSrc}`,
+        // == RFC 9073 (https://datatracker.ietf.org/doc/html/rfc9073)
+        // ===
+        'END:VEVENT',
+    ];
+
+    // Fold lines and return as array
+    const folded: string[] = [];
+    for (const rl of rawLines) {
+        folded.push(...foldICSLine(rl));
+    }
+
+    return folded;
+}
+
+export const GET: RequestHandler = async () => {
+    const icsLines = [
+        'BEGIN:VCALENDAR',
+        // == RFC 5545 (https://datatracker.ietf.org/doc/html/rfc5545)
+        'CALSCALE:GREGORIAN',
+        stringProperty("PRODID", `-//${IMPLEMENTATION_DOMAIN}//${IMPLEMENTATION_ID}//DE`),
+        'VERSION:2.0',
+        // == RFC 7986 (https://datatracker.ietf.org/doc/html/rfc7986)
+        ...languageProperty("NAME", { de: "SMD-KA Kalender", en: "SMD-KA Calendar" }),
+        `REFRESH-INTERVAL;VALUE=DURATION:PT4H`,  // same as Cache-Control
+        // https://learn.microsoft.com/en-us/openspecs/exchange_server_protocols/ms-oxcical/1da58449-b97e-46bd-b018-a1ce576f3e6d
+        // (this is older & some clients may only understand this one)
+        stringProperty("X-WR-CALNAME", "SMD-KA Calendar"),
+    ];
+    const eventRecords = await retrieveEvents();
+    for (const record of eventRecords) {
+        icsLines.push(...recordToVeventLines(record))
+    }
+    icsLines.push(
+        'END:VCALENDAR',
+        '',  // end file with line ending
+    )
+    const ics = icsLines.join('\r\n');
+
+    return new Response(ics, {
+        headers: {
+            'Content-Type': 'text/calendar; charset=utf-8',
+            // inline usually prevents a forced download dialog in some browsers; keep file name for clients that inspect it
+            'Content-Disposition': 'inline; filename="calendar.ics"',
+            // optionally allow caching; adjust as needed
+            'Cache-Control': 'public, max-age=14400'  // PT4H, same as REFRESH-INTERVAL
+        }
+    });
+};

--- a/frontend/src/routes/events/kalender/image-mime.ts
+++ b/frontend/src/routes/events/kalender/image-mime.ts
@@ -1,0 +1,90 @@
+/**
+ * Small utilities to extract a file suffix and map it to a common image MIME type.
+ * The lookup is optimized by building a mapping (object) from extensions -> mime at module init.
+ */
+
+type ImageMimeEntry = { exts: string[]; mime: string };
+
+/** Configure common image MIME types here (add/remove as required) */
+export const imageMimeConfig: ImageMimeEntry[] = [
+    { exts: ['png'], mime: 'image/png' },
+    { exts: ['jpg', 'jpeg', 'jpe'], mime: 'image/jpeg' },
+    { exts: ['gif'], mime: 'image/gif' },
+    { exts: ['webp'], mime: 'image/webp' },
+    { exts: ['avif'], mime: 'image/avif' },
+    { exts: ['svg'], mime: 'image/svg+xml' },
+    { exts: ['bmp'], mime: 'image/bmp' },
+    { exts: ['tif', 'tiff'], mime: 'image/tiff' },
+    { exts: ['ico', 'cur'], mime: 'image/x-icon' }
+];
+
+/**
+ * Build a fast lookup map from extension -> mime type.
+ * Uses a plain object with no prototype to avoid accidental collisions.
+ */
+function buildImageMimeMap(config: ImageMimeEntry[]) {
+    const map: Record<string, string> = Object.create(null);
+    for (const entry of config) {
+        for (const e of entry.exts) {
+            map[e.toLowerCase()] = entry.mime;
+        }
+    }
+    return map;
+}
+
+/** The fast lookup map used by getImageMimeType */
+export const imageMimeMap = buildImageMimeMap(imageMimeConfig);
+
+/**
+ * Extracts the file suffix (extension) from a filename or URL.
+ * - Strips query string and fragment.
+ * - Returns the extension in lower-case (without the dot), or null if none.
+ */
+export function getFileSuffix(name: string): string | null {
+    if (!name) return null;
+    // remove query string and fragment
+    const base = name.split(/[?#]/, 1)[0];
+    const lastDot = base.lastIndexOf('.');
+    if (lastDot <= 0 || lastDot === base.length - 1) return null; // no extension or hidden file like ".env"
+    return base.slice(lastDot + 1).toLowerCase();
+}
+
+/**
+ * Determine the image MIME type for a given filename/URL or a plain extension.
+ * Uses the pre-built imageMimeMap for O(1) lookup.
+ *
+ * Accepts either:
+ *  - a full filename or URL: "photo.JPG", "https://.../img.png?size=large"
+ *  - or a raw extension: "jpg" or ".jpg"
+ *
+ * Returns the MIME string (e.g. "image/png") or null if not in the configured list.
+ */
+export function getImageMimeType(input: string): string | null {
+    if (!input) return null;
+
+    // if input starts with a dot, strip it
+    const maybeExt = input.startsWith('.') ? input.slice(1) : input;
+    // if it contains path/query/fragment, extract suffix; otherwise treat as extension
+    const looksLikeName = /[\/.?#]/.test(maybeExt);
+    const ext = looksLikeName ? getFileSuffix(maybeExt) : maybeExt.toLowerCase();
+
+    if (!ext) return null;
+    return imageMimeMap[ext] ?? null;
+}
+
+/* Example usage:
+
+import { getFileSuffix, getImageMimeType, imageMimeMap } from './image-mime';
+
+console.log(getFileSuffix('photo.jpeg')); // "jpeg"
+console.log(getFileSuffix('https://example.com/a/b/c.png?x=1#foo')); // "png"
+console.log(getFileSuffix('.env')); // null
+
+console.log(getImageMimeType('avatar.PNG')); // "image/png"
+console.log(getImageMimeType('.jpg')); // "image/jpeg"
+console.log(getImageMimeType('unknown.ext')); // null
+
+// You can inspect the built map:
+console.log(imageMimeMap); // { png: 'image/png', jpg: 'image/jpeg', ... }
+
+*/


### PR DESCRIPTION
This adds an endpoint providing an endpoint which exports the calendar (except german bible study events, same as on the calendar page) via iCalendar. This endpoint can be subscribed to by calendar apps.

@Techthy If it is okay to you, I would like to push this to main for a small test phase. I am not sure whether enough clients out there support multilingual iCalendar files. If the link is published, it would be easy to let others try that out. If most clients do not support that, I would change the endpoint to allow users to select which language they prefer. Or what do you think?