### PR TITLE
homepage: make text on heroshot mix-blending

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -49,7 +49,7 @@
 
 <HeroShot imgSrc={header} bgPosition={'bg-[center_left_60%]'}>
 	<div
-		class="text-grey absolute left-1/2 top-1/3 w-full -translate-x-1/2 -translate-y-1/2 px-4 text-center"
+		class="absolute left-1/2 top-1/3 w-full -translate-x-1/2 -translate-y-1/2 px-4 text-center text-white mix-blend-difference"
 	>
 		<div class="font-mincho text-4xl sm:text-5xl xl:text-7xl">Hier bist du richtig!</div>
 		<div class="font-caveat text-xl sm:text-2xl xl:text-3xl">


### PR DESCRIPTION
This change is subtle & open to debate. I propose this because I think this effect looks funny & may be useful in the future, but it is not really required.

It makes the text on the heroshot blend dynamically based on the current background. With the current picture & most aspect ratios, it makes nearly no difference, but in case the picture gets changed in the future or so, or someone has a really weird aspect ratio, it does. This is the state after this PR:

<img width="1812" height="466" alt="image" src="https://github.com/user-attachments/assets/e6eb034f-c823-4e40-b6c4-c72cc38064be" />

However, this shifts the "general" color a little bit, see comparison here:

Before:
<img width="719" height="138" alt="image" src="https://github.com/user-attachments/assets/7b5a3c81-972b-4860-8708-8bbf4c87ffe5" />

After:
<img width="715" height="148" alt="image" src="https://github.com/user-attachments/assets/4f9b25c7-0426-4026-b186-2d8ecfa37071" />

@Techthy what do you think?