### PR TITLE
Deduplicate & Generalize Navigation & Logout Code

### DIFF
--- a/frontend/src/lib/components/NavbarProfile.svelte
+++ b/frontend/src/lib/components/NavbarProfile.svelte
@@ -3,7 +3,7 @@
 	import Fa from 'svelte-fa';
 	import { page } from '$app/stores';
 	import { getAvatarUrl, pb } from '$lib/pocketbase';
-	import { applyAction, enhance } from '$app/forms';
+	import { logout } from '$lib/logout';
 	import loadingSpinner from '$lib/assets/loading_spinner.gif';
 
 	let isValid = pb.authStore.isValid;
@@ -31,21 +31,16 @@
 		<a class="menu-link" href="/intern">Dashboard</a>
 		<a class="menu-link" href="/intern/profile">Profil</a>
 
-		<form
+		<button
 			class="menu-link"
-			method="POST"
-			action="/account/logout"
-			use:enhance={() => {
+			on:click={async () => {
 				loading = true;
-				return async ({ result }) => {
-					pb.authStore.clear();
-					await applyAction(result);
-					loading = false;
-				};
+				await logout();
+				loading = false;
 			}}
 		>
-			<button>Ausloggen</button>
-		</form>
+			Ausloggen
+		</button>
 	</div>
 {:else}
 	<a href="/account/login" title="Anmelden">

--- a/frontend/src/lib/components/NavbarProfile.svelte
+++ b/frontend/src/lib/components/NavbarProfile.svelte
@@ -48,7 +48,7 @@
 		</form>
 	</div>
 {:else}
-	<a href="/account/login">
+	<a href="/account/login" title="Anmelden">
 		<Fa
 			class={$page.url.pathname.match('account/login') ? 'text-primary' : 'hover:text-primary'}
 			icon={faRightToBracket}

--- a/frontend/src/lib/components/navigation/NavRouteItem.svelte
+++ b/frontend/src/lib/components/navigation/NavRouteItem.svelte
@@ -9,14 +9,28 @@
 	export let forMobile: boolean = false;
 </script>
 
-<a class="{forMobile ? 'mobile' : 'desktop'} {itemClass}" href={route.url}>
-	<slot>
-		{route.name}
-		{#if route.extern}
-			<Fa class="text-lg" icon={faArrowUpRightFromSquare}></Fa>
-		{/if}
-	</slot>
-</a>
+{#if route.action}
+	<button
+		class="{forMobile ? 'mobile' : 'desktop'} {itemClass}"
+		on:click={route.action ? () => route.action?.() : undefined}
+	>
+		<slot>
+			{route.name}
+			{#if route.extern}
+				<Fa class="text-lg" icon={faArrowUpRightFromSquare}></Fa>
+			{/if}
+		</slot>
+	</button>
+{:else if route.url}
+	<a class="{forMobile ? 'mobile' : 'desktop'} {itemClass}" href={route.url}>
+		<slot>
+			{route.name}
+			{#if route.extern}
+				<Fa class="text-lg" icon={faArrowUpRightFromSquare}></Fa>
+			{/if}
+		</slot>
+	</a>
+{/if}
 
 <style>
 	.desktop {

--- a/frontend/src/lib/components/navigation/NavRouteItem.svelte
+++ b/frontend/src/lib/components/navigation/NavRouteItem.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import type { FullNavTabRoute } from './types';
+	import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
+	import Fa from 'svelte-fa/src/fa.svelte';
+
+	export let route: FullNavTabRoute;
+	let itemClass: string = '';
+	export { itemClass as class };
+	export let forMobile: boolean = false;
+</script>
+
+<a class="{forMobile ? 'mobile' : 'desktop'} {itemClass}" href={route.url}>
+	<slot>
+		{route.name}
+		{#if route.extern}
+			<Fa class="text-lg" icon={faArrowUpRightFromSquare}></Fa>
+		{/if}
+	</slot>
+</a>
+
+<style>
+	.desktop {
+		@apply px-4 py-2 hover:bg-gray-100 hover:text-black;
+	}
+	.mobile {
+		/* nothing to apply yet */
+	}
+</style>

--- a/frontend/src/lib/components/navigation/NavbarTab.svelte
+++ b/frontend/src/lib/components/navigation/NavbarTab.svelte
@@ -9,7 +9,7 @@
 	import type { NavTab } from './types';
 </script>
 
-<a href={tab.defaultUrl}>
+<a href={tab.defaultUrl ?? null}>
 	<span
 		class="CategoryTitle peer py-5 {$page.url.pathname.includes(tab.baseUrl) ? 'text-primary' : ''}"
 	>

--- a/frontend/src/lib/components/navigation/NavbarTab.svelte
+++ b/frontend/src/lib/components/navigation/NavbarTab.svelte
@@ -25,9 +25,10 @@
 		<div class="CategoryLinkList">
 			{#each tab.routes as route}
 				{#if userHasRole($currentUser, route.permission)}
+					{@const extern = route.extern ?? !route.url.startsWith('/')}
 					<a class="fa" href={route.url}>
 						{route.name}
-						{#if route.extern}
+						{#if extern}
 							<Fa class="text-lg" icon={faArrowUpRightFromSquare}></Fa>
 						{/if}
 					</a>

--- a/frontend/src/lib/components/navigation/NavbarTab.svelte
+++ b/frontend/src/lib/components/navigation/NavbarTab.svelte
@@ -9,12 +9,13 @@
 	import { inferNavTab, type NavTab } from './types';
 
 	// backend
-	import { currentUser, userHasRole } from '$lib/pocketbase';
+	import { currentUser } from '$lib/pocketbase';
 
-	let fTab = inferNavTab(tab);
+	let fTab;
+	$: fTab = inferNavTab($currentUser, tab);
 </script>
 
-{#if userHasRole($currentUser, fTab.permission)}
+{#if fTab !== null}
 	<a href={fTab.defaultUrl ?? null}>
 		<span
 			class="CategoryTitle peer py-5 {$page.url.pathname.includes(fTab.baseUrl)
@@ -26,14 +27,12 @@
 		</span>
 		<div class="CategoryLinkList">
 			{#each fTab.routes as route}
-				{#if userHasRole($currentUser, route.permission)}
-					<a class="fa" href={route.url}>
-						{route.name}
-						{#if route.extern}
-							<Fa class="text-lg" icon={faArrowUpRightFromSquare}></Fa>
-						{/if}
-					</a>
-				{/if}
+				<a class="fa" href={route.url}>
+					{route.name}
+					{#if route.extern}
+						<Fa class="text-lg" icon={faArrowUpRightFromSquare}></Fa>
+					{/if}
+				</a>
 			{/each}
 		</div>
 	</a>

--- a/frontend/src/lib/components/navigation/NavbarTab.svelte
+++ b/frontend/src/lib/components/navigation/NavbarTab.svelte
@@ -2,7 +2,7 @@
 	// args
 	export let tab: NavTab;
 
-	import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
+	import { faArrowUpRightFromSquare, faChevronDown } from '@fortawesome/free-solid-svg-icons';
 	import Fa from 'svelte-fa/src/fa.svelte';
 	import { page } from '$app/stores';
 
@@ -24,6 +24,9 @@
 			{#if userHasRole($currentUser, route.permission)}
 				<a class="fa" href={route.url}>
 					{route.name}
+					{#if route.extern}
+						<Fa class="text-lg" icon={faArrowUpRightFromSquare}></Fa>
+					{/if}
 				</a>
 			{/if}
 		{/each}

--- a/frontend/src/lib/components/navigation/NavbarTab.svelte
+++ b/frontend/src/lib/components/navigation/NavbarTab.svelte
@@ -27,7 +27,7 @@
 			<Fa class="text-lg" icon={faChevronDown}></Fa>
 		</span>
 		<div class="CategoryLinkList">
-			{#each fTab.routes as route}
+			{#each fTab.routes.filter((r) => r.showDesktop) as route}
 				<NavRouteItem {route} class="fa" />
 			{/each}
 		</div>

--- a/frontend/src/lib/components/navigation/NavbarTab.svelte
+++ b/frontend/src/lib/components/navigation/NavbarTab.svelte
@@ -36,6 +36,9 @@
 	}
 
 	.CategoryTitle {
-		@apply hover:text-primary flex items-center gap-2 hover:cursor-pointer;
+		@apply hover:text-primary flex cursor-default items-center gap-2;
+	}
+	[href] > .CategoryTitle {
+		@apply cursor-pointer;
 	}
 </style>

--- a/frontend/src/lib/components/navigation/NavbarTab.svelte
+++ b/frontend/src/lib/components/navigation/NavbarTab.svelte
@@ -7,6 +7,9 @@
 	import { page } from '$app/stores';
 
 	import type { NavTab } from './types';
+
+	// backend
+	import { currentUser, userHasRole } from '$lib/pocketbase';
 </script>
 
 <a href={tab.defaultUrl ?? null}>
@@ -18,7 +21,11 @@
 	</span>
 	<div class="CategoryLinkList">
 		{#each tab.routes as route}
-			<a href={route.url}>{route.name}</a>
+			{#if userHasRole($currentUser, route.permission)}
+				<a class="fa" href={route.url}>
+					{route.name}
+				</a>
+			{/if}
 		{/each}
 	</div>
 </a>

--- a/frontend/src/lib/components/navigation/NavbarTab.svelte
+++ b/frontend/src/lib/components/navigation/NavbarTab.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	// args
+	export let tab: NavTab;
+
+	import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
+	import Fa from 'svelte-fa/src/fa.svelte';
+	import { page } from '$app/stores';
+
+	import type { NavTab } from './types';
+</script>
+
+<a href={tab.defaultUrl}>
+	<span
+		class="CategoryTitle peer py-5 {$page.url.pathname.includes(tab.baseUrl) ? 'text-primary' : ''}"
+	>
+		{tab.name}
+		<Fa class="text-lg" icon={faChevronDown}></Fa>
+	</span>
+	<div class="CategoryLinkList">
+		{#each tab.routes as route}
+			<a href={route.url}>{route.name}</a>
+		{/each}
+	</div>
+</a>
+
+<style>
+	a {
+		@apply no-underline;
+	}
+
+	.CategoryLinkList {
+		@apply bg-primary absolute top-[4.25rem] hidden justify-center  hover:grid peer-hover:grid;
+	}
+	.CategoryLinkList > a {
+		@apply px-4 py-2 hover:bg-gray-100 hover:text-black;
+	}
+
+	.CategoryTitle {
+		@apply hover:text-primary flex items-center gap-2 hover:cursor-pointer;
+	}
+</style>

--- a/frontend/src/lib/components/navigation/NavbarTab.svelte
+++ b/frontend/src/lib/components/navigation/NavbarTab.svelte
@@ -12,26 +12,30 @@
 	import { currentUser, userHasRole } from '$lib/pocketbase';
 </script>
 
-<a href={tab.defaultUrl ?? null}>
-	<span
-		class="CategoryTitle peer py-5 {$page.url.pathname.includes(tab.baseUrl) ? 'text-primary' : ''}"
-	>
-		{tab.name}
-		<Fa class="text-lg" icon={faChevronDown}></Fa>
-	</span>
-	<div class="CategoryLinkList">
-		{#each tab.routes as route}
-			{#if userHasRole($currentUser, route.permission)}
-				<a class="fa" href={route.url}>
-					{route.name}
-					{#if route.extern}
-						<Fa class="text-lg" icon={faArrowUpRightFromSquare}></Fa>
-					{/if}
-				</a>
-			{/if}
-		{/each}
-	</div>
-</a>
+{#if userHasRole($currentUser, tab.permission)}
+	<a href={tab.defaultUrl ?? null}>
+		<span
+			class="CategoryTitle peer py-5 {$page.url.pathname.includes(tab.baseUrl)
+				? 'text-primary'
+				: ''}"
+		>
+			{tab.name}
+			<Fa class="text-lg" icon={faChevronDown}></Fa>
+		</span>
+		<div class="CategoryLinkList">
+			{#each tab.routes as route}
+				{#if userHasRole($currentUser, route.permission)}
+					<a class="fa" href={route.url}>
+						{route.name}
+						{#if route.extern}
+							<Fa class="text-lg" icon={faArrowUpRightFromSquare}></Fa>
+						{/if}
+					</a>
+				{/if}
+			{/each}
+		</div>
+	</a>
+{/if}
 
 <style>
 	a {

--- a/frontend/src/lib/components/navigation/NavbarTab.svelte
+++ b/frontend/src/lib/components/navigation/NavbarTab.svelte
@@ -2,11 +2,12 @@
 	// args
 	export let tab: NavTab;
 
-	import { faArrowUpRightFromSquare, faChevronDown } from '@fortawesome/free-solid-svg-icons';
+	import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
 	import Fa from 'svelte-fa/src/fa.svelte';
 	import { page } from '$app/stores';
 
 	import { inferNavTab, type NavTab } from './types';
+	import NavRouteItem from './NavRouteItem.svelte';
 
 	// backend
 	import { currentUser } from '$lib/pocketbase';
@@ -27,12 +28,7 @@
 		</span>
 		<div class="CategoryLinkList">
 			{#each fTab.routes as route}
-				<a class="fa" href={route.url}>
-					{route.name}
-					{#if route.extern}
-						<Fa class="text-lg" icon={faArrowUpRightFromSquare}></Fa>
-					{/if}
-				</a>
+				<NavRouteItem {route} class="fa" />
 			{/each}
 		</div>
 	</a>
@@ -45,9 +41,6 @@
 
 	.CategoryLinkList {
 		@apply bg-primary absolute top-[4.25rem] hidden justify-center  hover:grid peer-hover:grid;
-	}
-	.CategoryLinkList > a {
-		@apply px-4 py-2 hover:bg-gray-100 hover:text-black;
 	}
 
 	.CategoryTitle {

--- a/frontend/src/lib/components/navigation/NavbarTab.svelte
+++ b/frontend/src/lib/components/navigation/NavbarTab.svelte
@@ -6,29 +6,30 @@
 	import Fa from 'svelte-fa/src/fa.svelte';
 	import { page } from '$app/stores';
 
-	import type { NavTab } from './types';
+	import { inferNavTab, type NavTab } from './types';
 
 	// backend
 	import { currentUser, userHasRole } from '$lib/pocketbase';
+
+	let fTab = inferNavTab(tab);
 </script>
 
-{#if userHasRole($currentUser, tab.permission)}
-	<a href={tab.defaultUrl ?? null}>
+{#if userHasRole($currentUser, fTab.permission)}
+	<a href={fTab.defaultUrl ?? null}>
 		<span
-			class="CategoryTitle peer py-5 {$page.url.pathname.includes(tab.baseUrl)
+			class="CategoryTitle peer py-5 {$page.url.pathname.includes(fTab.baseUrl)
 				? 'text-primary'
 				: ''}"
 		>
-			{tab.name}
+			{fTab.name}
 			<Fa class="text-lg" icon={faChevronDown}></Fa>
 		</span>
 		<div class="CategoryLinkList">
-			{#each tab.routes as route}
+			{#each fTab.routes as route}
 				{#if userHasRole($currentUser, route.permission)}
-					{@const extern = route.extern ?? !route.url.startsWith('/')}
 					<a class="fa" href={route.url}>
 						{route.name}
-						{#if extern}
+						{#if route.extern}
 							<Fa class="text-lg" icon={faArrowUpRightFromSquare}></Fa>
 						{/if}
 					</a>

--- a/frontend/src/lib/components/navigation/NavlistGroup.svelte
+++ b/frontend/src/lib/components/navigation/NavlistGroup.svelte
@@ -16,32 +16,34 @@
 	let fTab = inferNavTab(tab);
 </script>
 
-<div>
-	<h3 class="text-white">
-		<!-- manual check because of on:click -->
-		{#if fTab.defaultUrl ?? false}
-			<a href={fTab.defaultUrl} on:click={() => (showMenu = false)}>
-				{fTab.name}
-			</a>
-		{:else}
-			{fTab.name}
-		{/if}
-	</h3>
-	<button on:click={() => (showMenu = false)} class="flex flex-col text-left text-xl">
-		{#each fTab.routes as route}
-			{@const showMobile = route.showMobile ?? true}
-			{@const isAuthorized = userHasRole($currentUser, fTab.permission)}
-			{#if showMobile && isAuthorized}
-				<a class="fa ml-4" href={route.url}>
-					{route.name}
-					{#if route.extern}
-						<Fa class="text-lg" icon={faArrowUpRightFromSquare}></Fa>
-					{/if}
+{#if userHasRole($currentUser, fTab.permission)}
+	<div>
+		<h3 class="text-white">
+			<!-- manual check because of on:click -->
+			{#if fTab.defaultUrl ?? false}
+				<a href={fTab.defaultUrl} on:click={() => (showMenu = false)}>
+					{fTab.name}
 				</a>
+			{:else}
+				{fTab.name}
 			{/if}
-		{/each}
-	</button>
-</div>
+		</h3>
+		<button on:click={() => (showMenu = false)} class="flex flex-col text-left text-xl">
+			{#each fTab.routes as route}
+				{@const showMobile = route.showMobile ?? true}
+				{@const isAuthorized = userHasRole($currentUser, fTab.permission)}
+				{#if showMobile && isAuthorized}
+					<a class="fa ml-4" href={route.url}>
+						{route.name}
+						{#if route.extern}
+							<Fa class="text-lg" icon={faArrowUpRightFromSquare}></Fa>
+						{/if}
+					</a>
+				{/if}
+			{/each}
+		</button>
+	</div>
+{/if}
 
 <style>
 	h3 {

--- a/frontend/src/lib/components/navigation/NavlistGroup.svelte
+++ b/frontend/src/lib/components/navigation/NavlistGroup.svelte
@@ -5,10 +5,7 @@
 	export let showMenu: boolean;
 
 	import { inferNavTab, type NavTab } from './types';
-
-	// UI elements
-	import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
-	import Fa from 'svelte-fa/src/fa.svelte';
+	import NavRouteItem from './NavRouteItem.svelte';
 
 	// backend
 	import { currentUser } from '$lib/pocketbase';
@@ -31,12 +28,7 @@
 		</h3>
 		<button on:click={() => (showMenu = false)} class="flex flex-col text-left text-xl">
 			{#each fTab.routes.filter((r) => r.showMobile) as route}
-				<a class="fa ml-4" href={route.url}>
-					{route.name}
-					{#if route.extern}
-						<Fa class="text-lg" icon={faArrowUpRightFromSquare}></Fa>
-					{/if}
-				</a>
+				<NavRouteItem {route} class="fa ml-4" forMobile={true} />
 			{/each}
 		</button>
 	</div>

--- a/frontend/src/lib/components/navigation/NavlistGroup.svelte
+++ b/frontend/src/lib/components/navigation/NavlistGroup.svelte
@@ -20,7 +20,10 @@
 	</h3>
 	<button on:click={() => (showMenu = false)} class="flex flex-col text-left text-xl">
 		{#each tab.routes as route}
-			<a class="ml-4" href={route.url}>{route.name}</a>
+			{@const showMobile = route.showMobile ?? true}
+			{#if showMobile}
+				<a class="ml-4" href={route.url}>{route.name}</a>
+			{/if}
 		{/each}
 	</button>
 </div>

--- a/frontend/src/lib/components/navigation/NavlistGroup.svelte
+++ b/frontend/src/lib/components/navigation/NavlistGroup.svelte
@@ -31,9 +31,10 @@
 			{@const showMobile = route.showMobile ?? true}
 			{@const isAuthorized = userHasRole($currentUser, tab.permission)}
 			{#if showMobile && isAuthorized}
+				{@const extern = route.extern ?? !route.url.startsWith('/')}
 				<a class="fa ml-4" href={route.url}>
 					{route.name}
-					{#if route.extern}
+					{#if extern}
 						<Fa class="text-lg" icon={faArrowUpRightFromSquare}></Fa>
 					{/if}
 				</a>

--- a/frontend/src/lib/components/navigation/NavlistGroup.svelte
+++ b/frontend/src/lib/components/navigation/NavlistGroup.svelte
@@ -11,12 +11,13 @@
 	import Fa from 'svelte-fa/src/fa.svelte';
 
 	// backend
-	import { currentUser, userHasRole } from '$lib/pocketbase';
+	import { currentUser } from '$lib/pocketbase';
 
-	let fTab = inferNavTab(tab);
+	let fTab;
+	$: fTab = inferNavTab($currentUser, tab);
 </script>
 
-{#if userHasRole($currentUser, fTab.permission)}
+{#if fTab !== null}
 	<div>
 		<h3 class="text-white">
 			<!-- manual check because of on:click -->
@@ -29,17 +30,13 @@
 			{/if}
 		</h3>
 		<button on:click={() => (showMenu = false)} class="flex flex-col text-left text-xl">
-			{#each fTab.routes as route}
-				{@const showMobile = route.showMobile ?? true}
-				{@const isAuthorized = userHasRole($currentUser, fTab.permission)}
-				{#if showMobile && isAuthorized}
-					<a class="fa ml-4" href={route.url}>
-						{route.name}
-						{#if route.extern}
-							<Fa class="text-lg" icon={faArrowUpRightFromSquare}></Fa>
-						{/if}
-					</a>
-				{/if}
+			{#each fTab.routes.filter((r) => r.showMobile) as route}
+				<a class="fa ml-4" href={route.url}>
+					{route.name}
+					{#if route.extern}
+						<Fa class="text-lg" icon={faArrowUpRightFromSquare}></Fa>
+					{/if}
+				</a>
 			{/each}
 		</button>
 	</div>

--- a/frontend/src/lib/components/navigation/NavlistGroup.svelte
+++ b/frontend/src/lib/components/navigation/NavlistGroup.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	// args
+	export let tab: NavTab;
+	// bindables (becomes explicit in Svelte 5)
+	export let showMenu: boolean;
+
+	import type { NavTab } from './types';
+</script>
+
+<div>
+	<h3 class="text-white">
+		{tab.name}
+	</h3>
+	<button on:click={() => (showMenu = false)} class="flex flex-col text-left text-xl">
+		{#each tab.routes as route}
+			<a class="ml-4" href={route.url}>{route.name}</a>
+		{/each}
+	</button>
+</div>
+
+<style>
+	h3 {
+		@apply font-normal;
+	}
+</style>

--- a/frontend/src/lib/components/navigation/NavlistGroup.svelte
+++ b/frontend/src/lib/components/navigation/NavlistGroup.svelte
@@ -4,7 +4,12 @@
 	// bindables (becomes explicit in Svelte 5)
 	export let showMenu: boolean;
 
+	// types
 	import type { NavTab } from './types';
+
+	// UI elements
+	import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
+	import Fa from 'svelte-fa/src/fa.svelte';
 
 	// backend
 	import { currentUser, userHasRole } from '$lib/pocketbase';
@@ -26,7 +31,12 @@
 			{@const showMobile = route.showMobile ?? true}
 			{@const isAuthorized = userHasRole($currentUser, tab.permission)}
 			{#if showMobile && isAuthorized}
-				<a class="ml-4" href={route.url}>{route.name}</a>
+				<a class="fa ml-4" href={route.url}>
+					{route.name}
+					{#if route.extern}
+						<Fa class="text-lg" icon={faArrowUpRightFromSquare}></Fa>
+					{/if}
+				</a>
 			{/if}
 		{/each}
 	</button>

--- a/frontend/src/lib/components/navigation/NavlistGroup.svelte
+++ b/frontend/src/lib/components/navigation/NavlistGroup.svelte
@@ -4,8 +4,7 @@
 	// bindables (becomes explicit in Svelte 5)
 	export let showMenu: boolean;
 
-	// types
-	import type { NavTab } from './types';
+	import { inferNavTab, type NavTab } from './types';
 
 	// UI elements
 	import { faArrowUpRightFromSquare } from '@fortawesome/free-solid-svg-icons';
@@ -13,28 +12,29 @@
 
 	// backend
 	import { currentUser, userHasRole } from '$lib/pocketbase';
+
+	let fTab = inferNavTab(tab);
 </script>
 
 <div>
 	<h3 class="text-white">
 		<!-- manual check because of on:click -->
-		{#if tab.defaultUrl ?? false}
-			<a href={tab.defaultUrl} on:click={() => (showMenu = false)}>
-				{tab.name}
+		{#if fTab.defaultUrl ?? false}
+			<a href={fTab.defaultUrl} on:click={() => (showMenu = false)}>
+				{fTab.name}
 			</a>
 		{:else}
-			{tab.name}
+			{fTab.name}
 		{/if}
 	</h3>
 	<button on:click={() => (showMenu = false)} class="flex flex-col text-left text-xl">
-		{#each tab.routes as route}
+		{#each fTab.routes as route}
 			{@const showMobile = route.showMobile ?? true}
-			{@const isAuthorized = userHasRole($currentUser, tab.permission)}
+			{@const isAuthorized = userHasRole($currentUser, fTab.permission)}
 			{#if showMobile && isAuthorized}
-				{@const extern = route.extern ?? !route.url.startsWith('/')}
 				<a class="fa ml-4" href={route.url}>
 					{route.name}
-					{#if extern}
+					{#if route.extern}
 						<Fa class="text-lg" icon={faArrowUpRightFromSquare}></Fa>
 					{/if}
 				</a>

--- a/frontend/src/lib/components/navigation/NavlistGroup.svelte
+++ b/frontend/src/lib/components/navigation/NavlistGroup.svelte
@@ -5,6 +5,9 @@
 	export let showMenu: boolean;
 
 	import type { NavTab } from './types';
+
+	// backend
+	import { currentUser, userHasRole } from '$lib/pocketbase';
 </script>
 
 <div>
@@ -21,7 +24,8 @@
 	<button on:click={() => (showMenu = false)} class="flex flex-col text-left text-xl">
 		{#each tab.routes as route}
 			{@const showMobile = route.showMobile ?? true}
-			{#if showMobile}
+			{@const isAuthorized = userHasRole($currentUser, tab.permission)}
+			{#if showMobile && isAuthorized}
 				<a class="ml-4" href={route.url}>{route.name}</a>
 			{/if}
 		{/each}

--- a/frontend/src/lib/components/navigation/NavlistGroup.svelte
+++ b/frontend/src/lib/components/navigation/NavlistGroup.svelte
@@ -9,7 +9,14 @@
 
 <div>
 	<h3 class="text-white">
-		{tab.name}
+		<!-- manual check because of on:click -->
+		{#if tab.defaultUrl ?? false}
+			<a href={tab.defaultUrl} on:click={() => (showMenu = false)}>
+				{tab.name}
+			</a>
+		{:else}
+			{tab.name}
+		{/if}
 	</h3>
 	<button on:click={() => (showMenu = false)} class="flex flex-col text-left text-xl">
 		{#each tab.routes as route}

--- a/frontend/src/lib/components/navigation/types.ts
+++ b/frontend/src/lib/components/navigation/types.ts
@@ -1,8 +1,11 @@
 import { userMayAccess, type MaybeModel, type RoleGuarded } from "$lib/pocketbase";
 
+export type NavRouteAction = () => Promise<unknown> | unknown;
+
 export interface NavTabRoute extends RoleGuarded {
     name: string;
-    url: string;
+    url?: string;
+    action?: NavRouteAction;
     showMobile?: boolean;
     extern?: boolean;
 }
@@ -31,7 +34,7 @@ function inferNavTabRoute(user: MaybeModel, route: NavTabRoute): FullNavTabRoute
         return null;
     return {
         showMobile: true,
-        extern: !route.url.startsWith('/'),
+        extern: route.url ? !route.url.startsWith('/') : false,
         ...route,  // order important
     }
 }

--- a/frontend/src/lib/components/navigation/types.ts
+++ b/frontend/src/lib/components/navigation/types.ts
@@ -1,9 +1,11 @@
+import type { Role } from "$lib/pocketbase";
+
 export interface NavTabRoute {
     name: string;
     url: string;
     showMobile?: boolean;
     extern?: boolean;
-    permission?: string;
+    permission?: Role;
 }
 
 export interface NavTab {

--- a/frontend/src/lib/components/navigation/types.ts
+++ b/frontend/src/lib/components/navigation/types.ts
@@ -15,3 +15,30 @@ export interface NavTab {
     permission?: Role;
     routes: NavTabRoute[];
 }
+
+// full variants have most attributes defined
+// should only be used for actually rendering those
+
+export interface FullNavTabRoute extends NavTabRoute {
+    showMobile: boolean;
+    extern: boolean;
+}
+
+export interface FullNavTab extends NavTab {
+    routes: FullNavTabRoute[];
+}
+
+function inferNavTabRoute(route: NavTabRoute): FullNavTabRoute {
+    return {
+        showMobile: true,
+        extern: !route.url.startsWith('/'),
+        ...route,  // order important
+    }
+}
+
+export function inferNavTab(tab: NavTab): FullNavTab {
+    return {
+        ...tab,  // order important
+        routes: tab.routes.map(inferNavTabRoute)
+    };
+}

--- a/frontend/src/lib/components/navigation/types.ts
+++ b/frontend/src/lib/components/navigation/types.ts
@@ -1,18 +1,16 @@
-import type { Role } from "$lib/pocketbase";
+import type { RoleGuarded } from "$lib/pocketbase";
 
-export interface NavTabRoute {
+export interface NavTabRoute extends RoleGuarded {
     name: string;
     url: string;
     showMobile?: boolean;
     extern?: boolean;
-    permission?: Role;
 }
 
-export interface NavTab {
+export interface NavTab extends RoleGuarded {
     name: string;
     baseUrl: string;
     defaultUrl?: string;
-    permission?: Role;
     routes: NavTabRoute[];
 }
 

--- a/frontend/src/lib/components/navigation/types.ts
+++ b/frontend/src/lib/components/navigation/types.ts
@@ -1,0 +1,14 @@
+export interface NavTabRoute {
+    name: string;
+    url: string;
+    showMobile?: boolean;
+    extern?: boolean;
+    permission?: string;
+}
+
+export interface NavTab {
+    name: string;
+    baseUrl: string;
+    defaultUrl?: string;
+    routes: NavTabRoute[];
+}

--- a/frontend/src/lib/components/navigation/types.ts
+++ b/frontend/src/lib/components/navigation/types.ts
@@ -12,5 +12,6 @@ export interface NavTab {
     name: string;
     baseUrl: string;
     defaultUrl?: string;
+    permission?: Role;
     routes: NavTabRoute[];
 }

--- a/frontend/src/lib/components/navigation/types.ts
+++ b/frontend/src/lib/components/navigation/types.ts
@@ -1,4 +1,4 @@
-import type { RoleGuarded } from "$lib/pocketbase";
+import { userMayAccess, type MaybeModel, type RoleGuarded } from "$lib/pocketbase";
 
 export interface NavTabRoute extends RoleGuarded {
     name: string;
@@ -26,7 +26,9 @@ export interface FullNavTab extends NavTab {
     routes: FullNavTabRoute[];
 }
 
-function inferNavTabRoute(route: NavTabRoute): FullNavTabRoute {
+function inferNavTabRoute(user: MaybeModel, route: NavTabRoute): FullNavTabRoute | null {
+    if (!userMayAccess(user, route))
+        return null;
     return {
         showMobile: true,
         extern: !route.url.startsWith('/'),
@@ -34,9 +36,14 @@ function inferNavTabRoute(route: NavTabRoute): FullNavTabRoute {
     }
 }
 
-export function inferNavTab(tab: NavTab): FullNavTab {
+/**
+ * @returns null if the user may not access this tab
+ */
+export function inferNavTab(user: MaybeModel, tab: NavTab): FullNavTab | null {
+    if (!userMayAccess(user, tab))
+        return null;
     return {
         ...tab,  // order important
-        routes: tab.routes.map(inferNavTabRoute)
+        routes: tab.routes.map((r) => inferNavTabRoute(user, r)).filter((r) => r !== null)
     };
 }

--- a/frontend/src/lib/components/navigation/types.ts
+++ b/frontend/src/lib/components/navigation/types.ts
@@ -6,6 +6,7 @@ export interface NavTabRoute extends RoleGuarded {
     name: string;
     url?: string;
     action?: NavRouteAction;
+    showDesktop?: boolean;
     showMobile?: boolean;
     extern?: boolean;
 }
@@ -21,6 +22,7 @@ export interface NavTab extends RoleGuarded {
 // should only be used for actually rendering those
 
 export interface FullNavTabRoute extends NavTabRoute {
+    showDesktop: boolean;
     showMobile: boolean;
     extern: boolean;
 }
@@ -33,6 +35,7 @@ function inferNavTabRoute(user: MaybeModel, route: NavTabRoute): FullNavTabRoute
     if (!userMayAccess(user, route))
         return null;
     return {
+        showDesktop: true,
         showMobile: true,
         extern: route.url ? !route.url.startsWith('/') : false,
         ...route,  // order important

--- a/frontend/src/lib/logout.ts
+++ b/frontend/src/lib/logout.ts
@@ -1,0 +1,28 @@
+import { pb } from './pocketbase';
+import { applyAction } from '$app/forms';
+
+/**
+ * Performs a logout by making a direct POST request to the logout endpoint.
+ * Then applies an redirect if the logout endpoint does send one.
+ *
+ * @param action - The form action URL (default: "/account/logout")
+ * @returns The response from the logout endpoint
+ */
+export async function logout(action: string = '/account/logout'): Promise<Response> {
+    // Make a direct POST request to the logout endpoint
+    const response = await fetch(action, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+        },
+    });
+    const result = await response.json().catch(() => ({}));
+
+    // After confirm, also apply logout locally
+    pb.authStore.clear();
+
+    // Apply the action result to handle any redirects or special responses
+    await applyAction(result);
+
+    return response;
+}

--- a/frontend/src/lib/pocketbase.ts
+++ b/frontend/src/lib/pocketbase.ts
@@ -1,4 +1,4 @@
-import PocketBase, { ClientResponseError } from 'pocketbase';
+import PocketBase, { BaseModel, ClientResponseError } from 'pocketbase';
 import { writable } from 'svelte/store';
 import defaultAvatar from '$lib/assets/user_default.png';
 const API_URL: string = import.meta.env.VITE_API_URL;
@@ -11,6 +11,22 @@ export const PRIT_RESPONSABLE = 'pritresponsable';
 export const REGIOKON_COORDINATOR = 'regiokoncordina';
 
 export type Role = typeof ANY_LOGGED_IN | typeof SAFT_COORDINATOR | typeof PRIT_RESPONSABLE | typeof REGIOKON_COORDINATOR;
+
+// argument "model" is there to make the function reactive
+// intended use in Svelte code: userHasRole($currentUser, requiredRole)
+export function userHasRole(model: BaseModel | null | undefined, role: Role | null | undefined): boolean {
+	const noRoleRequired = role === null || role === undefined
+	if (noRoleRequired)
+		return true;
+	const userNotLoggedIn = model === null || model == undefined
+	if (userNotLoggedIn)
+		return false;
+	const anyPermitted = role === ANY_LOGGED_IN;
+	if (anyPermitted)
+		return true;
+	const hasActualRole = model.roles.includes(role);
+	return hasActualRole;
+}
 
 export const currentUser = writable(pb.authStore.model);
 

--- a/frontend/src/lib/pocketbase.ts
+++ b/frontend/src/lib/pocketbase.ts
@@ -10,11 +10,12 @@ export const SAFT_COORDINATOR = 'saftcoordinator';
 export const PRIT_RESPONSABLE = 'pritresponsable';
 export const REGIOKON_COORDINATOR = 'regiokoncordina';
 
+export type MaybeModel = BaseModel | null | undefined;
 export type Role = typeof ANY_LOGGED_IN | typeof SAFT_COORDINATOR | typeof PRIT_RESPONSABLE | typeof REGIOKON_COORDINATOR;
 
 // argument "model" is there to make the function reactive
 // intended use in Svelte code: userHasRole($currentUser, requiredRole)
-export function userHasRole(model: BaseModel | null | undefined, role: Role | null | undefined): boolean {
+export function userHasRole(model: MaybeModel, role: Role | null | undefined): boolean {
 	const noRoleRequired = role === null || role === undefined
 	if (noRoleRequired)
 		return true;
@@ -29,6 +30,14 @@ export function userHasRole(model: BaseModel | null | undefined, role: Role | nu
 }
 
 export const currentUser = writable(pb.authStore.model);
+
+export interface RoleGuarded {
+	permission?: Role;
+}
+
+export function userMayAccess(model: MaybeModel, guarded: RoleGuarded): boolean {
+	return userHasRole(model, guarded.permission)
+}
 
 export function getErrorMessage(error: unknown) {
 	const errorObj = error as ClientResponseError;

--- a/frontend/src/lib/pocketbase.ts
+++ b/frontend/src/lib/pocketbase.ts
@@ -5,11 +5,12 @@ const API_URL: string = import.meta.env.VITE_API_URL;
 
 export const pb = new PocketBase(API_URL);
 
+export const ANY_LOGGED_IN = 'ANY_LOGGED_IN';  // "virtual role"
 export const SAFT_COORDINATOR = 'saftcoordinator';
 export const PRIT_RESPONSABLE = 'pritresponsable';
 export const REGIOKON_COORDINATOR = 'regiokoncordina';
 
-export type Role = typeof SAFT_COORDINATOR | typeof PRIT_RESPONSABLE | typeof REGIOKON_COORDINATOR;
+export type Role = typeof ANY_LOGGED_IN | typeof SAFT_COORDINATOR | typeof PRIT_RESPONSABLE | typeof REGIOKON_COORDINATOR;
 
 export const currentUser = writable(pb.authStore.model);
 

--- a/frontend/src/lib/pocketbase.ts
+++ b/frontend/src/lib/pocketbase.ts
@@ -9,6 +9,8 @@ export const SAFT_COORDINATOR = 'saftcoordinator';
 export const PRIT_RESPONSABLE = 'pritresponsable';
 export const REGIOKON_COORDINATOR = 'regiokoncordina';
 
+export type Role = typeof SAFT_COORDINATOR | typeof PRIT_RESPONSABLE | typeof REGIOKON_COORDINATOR;
+
 export const currentUser = writable(pb.authStore.model);
 
 export function getErrorMessage(error: unknown) {
@@ -49,7 +51,7 @@ export type UserRecord = {
 	phonenumber: string;
 	post_images: 'yes' | 'no';
 	rili: boolean;
-	roles: string[]; // Array of roles
+	roles: Role[]; // Array of roles
 	start_of_studies: string; // ISO date string
 	surname: string;
 	team: string;

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -198,6 +198,12 @@
 				url: '/intern/regiokon/list',
 				showMobile: false,
 				permission: REGIOKON_COORDINATOR
+			},
+			{
+				name: 'Ausloggen',
+				action: logout,
+				showDesktop: false,
+				showMobile: true
 			}
 		]
 	};

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+	import type { NavTab } from '$lib/components/navigation/types';
+	import NavbarTab from '$lib/components/navigation/NavbarTab.svelte';
+
 	import '../app.css';
 	import '@fontsource/anton';
 	import '@fontsource-variable/merriweather-sans';
@@ -58,7 +61,7 @@
 		});
 	});
 
-	const tabs = [
+	const tabs: NavTab[] = [
 		{
 			name: 'Über uns',
 			baseUrl: '/about',
@@ -126,7 +129,7 @@
 		}
 	];
 
-	const tabsIntern = {
+	const tabsIntern: NavTab = {
 		name: 'Intern',
 		baseUrl: '/intern',
 		routes: [
@@ -224,21 +227,7 @@
 
 			<div class="flex items-center gap-4 text-xl text-white max-lg:hidden">
 				{#each tabs as tab}
-					<a href={tab.defaultUrl}>
-						<span
-							class="CategoryTitle peer py-5 {$page.url.pathname.includes(tab.baseUrl)
-								? 'text-primary'
-								: ''}"
-						>
-							{tab.name}
-							<Fa class="text-lg" icon={faChevronDown}></Fa>
-						</span>
-						<div class="CategoryLinkList">
-							{#each tab.routes as route}
-								<a href={route.url}>{route.name}</a>
-							{/each}
-						</div>
-					</a>
+					<NavbarTab {tab} />
 				{/each}
 
 				{#if isValid}
@@ -430,6 +419,7 @@
 		@apply font-normal;
 	}
 
+	/* Category still required for rendering tabsIntern */
 	.CategoryLinkList {
 		@apply bg-primary absolute top-[4.25rem] hidden justify-center  hover:grid peer-hover:grid;
 	}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
 	import type { NavTab } from '$lib/components/navigation/types';
 	import NavbarTab from '$lib/components/navigation/NavbarTab.svelte';
 	import NavlistGroup from '$lib/components/navigation/NavlistGroup.svelte';
+	import { logout } from '$lib/logout';
 
 	import '../app.css';
 	import '@fontsource/anton';
@@ -39,7 +40,6 @@
 	import { onMount } from 'svelte';
 	import NavbarProfile from '$lib/components/NavbarProfile.svelte';
 	import { click_outside } from '$lib/click_outside';
-	import { applyAction, enhance } from '$app/forms';
 	import dayjs from 'dayjs';
 	import 'dayjs/locale/de';
 
@@ -264,38 +264,7 @@
 				class="mobile-nav-height bg-grey absolute top-0 z-0 mt-[4.5rem] w-fit max-w-full overflow-scroll p-4 pb-8 text-gray-300 lg:hidden"
 			>
 				{#if isValid}
-					<div>
-						<h3 class="text-white"><a href="/intern">SMD-KA Intern</a></h3>
-						<button on:click={() => (showMenu = false)} class="flex flex-col text-left text-xl">
-							{#each tabsIntern.routes as route}
-								{#if route.showMobile && (pb.authStore.model?.roles.includes(route.permission) || !route.permission)}
-									<a class="fa ml-4" href={route.url}>
-										{route.name}
-										{#if route.extern}
-											<Fa class="text-lg" icon={faArrowUpRightFromSquare}></Fa>
-										{/if}
-									</a>
-								{/if}
-							{/each}
-						</button>
-						<button on:click={() => (showMenu = false)} class="flex flex-col text-left text-xl">
-							<form
-								class="menu-link ml-4"
-								method="POST"
-								action="/account/logout"
-								use:enhance={() => {
-									loading = true;
-									return async ({ result }) => {
-										pb.authStore.clear();
-										await applyAction(result);
-										loading = false;
-									};
-								}}
-							>
-								<button>Ausloggen</button>
-							</form>
-						</button>
-					</div>
+					<NavlistGroup tab={tabsIntern} bind:showMenu />
 					<div class="bg-primary my-2 h-0.5"></div>
 				{/if}
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -300,7 +300,7 @@
 					<button on:click={() => (showMenu = false)}>
 						<h3 class="text-white">
 							<a class="flex items-center gap-2" href="/intern">
-								SMD-KA Intern
+								Anmelden
 								<Fa icon={faRightToBracket} />
 							</a>
 						</h3>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -22,6 +22,7 @@
 	} from '@fortawesome/free-solid-svg-icons';
 	import Fa from 'svelte-fa/src/fa.svelte';
 	import {
+		ANY_LOGGED_IN,
 		getAvatarUrl,
 		pb,
 		PRIT_RESPONSABLE,
@@ -132,6 +133,7 @@
 	const tabsIntern: NavTab = {
 		name: 'Intern',
 		baseUrl: '/intern',
+		permission: ANY_LOGGED_IN,
 		routes: [
 			{
 				name: 'Adressliste',
@@ -229,31 +231,7 @@
 				{#each tabs as tab}
 					<NavbarTab {tab} />
 				{/each}
-
-				{#if isValid}
-					<div>
-						<span
-							class="CategoryTitle peer py-5 {$page.url.pathname.includes(tabsIntern.baseUrl)
-								? 'text-primary'
-								: ''}"
-						>
-							{tabsIntern.name}
-							<Fa class="text-lg" icon={faChevronDown}></Fa>
-						</span>
-						<div class="CategoryLinkList">
-							{#each tabsIntern.routes as route}
-								{#if pb.authStore.model?.roles.includes(route.permission) || !route.permission}
-									<a class="fa" href={route.url}>
-										{route.name}
-										{#if route.extern}
-											<Fa class="text-lg" icon={faArrowUpRightFromSquare}></Fa>
-										{/if}
-									</a>
-								{/if}
-							{/each}
-						</div>
-					</div>
-				{/if}
+				<NavbarTab tab={tabsIntern} />
 
 				<a class="hover:text-primary" href="https://kings-cafe.de">International</a>
 
@@ -417,18 +395,6 @@
 
 	h3 {
 		@apply font-normal;
-	}
-
-	/* Category still required for rendering tabsIntern */
-	.CategoryLinkList {
-		@apply bg-primary absolute top-[4.25rem] hidden justify-center  hover:grid peer-hover:grid;
-	}
-	.CategoryLinkList > a {
-		@apply px-4 py-2 hover:bg-gray-100 hover:text-black;
-	}
-
-	.CategoryTitle {
-		@apply hover:text-primary flex items-center gap-2 hover:cursor-pointer;
 	}
 
 	.underline-a > a:hover {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -134,6 +134,7 @@
 	const tabsIntern: NavTab = {
 		name: 'Intern',
 		baseUrl: '/intern',
+		defaultUrl: '/intern',
 		permission: ANY_LOGGED_IN,
 		routes: [
 			{

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { NavTab } from '$lib/components/navigation/types';
 	import NavbarTab from '$lib/components/navigation/NavbarTab.svelte';
+	import NavlistGroup from '$lib/components/navigation/NavlistGroup.svelte';
 
 	import '../app.css';
 	import '@fontsource/anton';
@@ -285,16 +286,7 @@
 				{/if}
 
 				{#each tabs as tab}
-					<div>
-						<h3 class="text-white">
-							{tab.name}
-						</h3>
-						<button on:click={() => (showMenu = false)} class="flex flex-col text-left text-xl">
-							{#each tab.routes as route}
-								<a class="ml-4" href={route.url}>{route.name}</a>
-							{/each}
-						</button>
-					</div>
+					<NavlistGroup {tab} bind:showMenu />
 				{/each}
 				<div class="bg-primary my-2 h-0.5"></div>
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -161,34 +161,41 @@
 			{
 				name: 'Mastersheet',
 				url: 'https://docs.google.com/spreadsheets/d/1elIUUx3LKdrvCmuGbXDzUgSeF2iMWq7bZRdVswGHLYM/edit?usp=sharing',
-				extern: true
+				extern: true,
+				showMobile: false
 			},
 			{
 				name: 'Mitarbeiter Portal',
 				url: 'https://portal.smd.org/start',
-				extern: true
+				extern: true,
+				showMobile: false
 			},
 			{
 				name: 'Allergie-Liste',
-				url: '/intern/allergy-list'
+				url: '/intern/allergy-list',
+				showMobile: false
 			},
 			{
 				name: 'Gebetsbox',
-				url: '/intern/gebetsbox'
+				url: '/intern/gebetsbox',
+				showMobile: false
 			},
 			{
 				name: 'SAFT Anmeldungen',
 				url: '/intern/saft/list',
+				showMobile: false,
 				permission: SAFT_COORDINATOR
 			},
 			{
 				name: 'SAFT PRIT',
 				url: '/intern/saft/prit',
+				showMobile: false,
 				permission: PRIT_RESPONSABLE
 			},
 			{
 				name: 'Regiokon Anmeldungen',
 				url: '/intern/regiokon/list',
+				showMobile: false,
 				permission: REGIOKON_COORDINATOR
 			}
 		]

--- a/frontend/src/routes/intern/+page.svelte
+++ b/frontend/src/routes/intern/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { applyAction, enhance } from '$app/forms';
+	import { logout } from '$lib/logout';
 	import { PRIT_RESPONSABLE, REGIOKON_COORDINATOR, SAFT_COORDINATOR, pb } from '$lib/pocketbase';
 	import {
 		faAddressBook,
@@ -155,20 +155,15 @@
 		{/if}
 
 		<div class="tile">
-			<form
-				method="POST"
-				action="/account/logout"
-				use:enhance={() => {
+			<button
+				on:click={async () => {
 					loading = true;
-					return async ({ result }) => {
-						pb.authStore.clear();
-						await applyAction(result);
-						loading = false;
-					};
+					await logout();
+					loading = false;
 				}}
-				class=" text-primary flex flex-col items-center justify-center gap-4 py-4 text-xl"
+				class="text-primary flex flex-col items-center justify-center gap-4 py-4 text-xl"
 			>
-				<button class="hover:bg-curulean-dark flex gap-2 align-middle" type="submit">
+				<div class="hover:bg-curulean-dark flex gap-2 align-middle">
 					{#if loading}
 						<img src={loadingSpinner} class="h-7" alt="loading" />
 					{:else}
@@ -177,8 +172,8 @@
 							Logout
 						</div>
 					{/if}
-				</button>
-			</form>
+				</div>
+			</button>
 		</div>
 	</div>
 </main>


### PR DESCRIPTION
This PR changes a large portion of the code base around the navigation bars to simplify their maintenance in the future. I started to work on this while trying to migrate to Svelte 5.

There are only two changes which should be actually noticable for users:
- 8da523d66c6c6aec87fe916994fdc19b327ad6ac: change label of sign-in button to "Anmelden"
- bdae47f8ded4ac8ca551ff2d91745b31e12b7218: add defaultUrl to "Intern" tab (only a real change for desktop users)

All other changes are only under the hood.
As far as I am concerned, everything (outside of the two things above) should still look & behave the same.

Also, technically speaking, this brings following features which might be useful in the future:
- all tabs / sections can now easily be limited to certain roles
  - including the new "ANY" role, which means that anyone that is signed in
- also each route link can now be limited to certain roles as well
- further role links can be selectively hidden for desktop & mobile view