### PR TITLE
Add side_dish, fairy_lights, and likes_cooking fields to SAFT list

### DIFF
--- a/backend/migrations/1776691068_updated_saft_registrations.go
+++ b/backend/migrations/1776691068_updated_saft_registrations.go
@@ -1,0 +1,776 @@
+package migrations
+
+import (
+	"encoding/json"
+
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+func init() {
+	m.Register(func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("skzm3nv3gicpo9z")
+		if err != nil {
+			return err
+		}
+
+		// update collection data
+		if err := json.Unmarshal([]byte(`{
+			"viewQuery": "SELECT \n  saft.created,\n  saft.id as id,\n  saft.paid,\n  CAST(COALESCE((users.name || ' ' || users.surname), \n  (saft.name || ' ' || saft.surname)) AS TEXT) as name,\n  CAST(COALESCE(users.email, saft.email) AS TEXT) as email,\n  CAST(COALESCE(users.gender, saft.gender) AS TEXT) as gender,\n  CAST(COALESCE(users.phonenumber, saft.phonenumber) AS TEXT) as phonenumber,\n  saft.travel_option, saft.travel_comments, saft.[group],\n  saft.ticket, saft.brings_cake,\n  CAST(COALESCE(users.vegetarian, saft.is_vegetarian) AS BOOL) as is_vegetarian,\n  CAST(COALESCE(users.allergies, saft.allergies) AS TEXT) as allergies, \n  saft.would_sleep_on_floor, saft.semester, saft.comments, saft.post_images,\n  saft.pot, saft.bag, saft.bag_count, saft.pad, saft.pad_count, saft.tents, saft.comes_friday, saft.side_dish, saft.fairy_lights, saft.likes_cooking\n  from saft LEFT JOIN users on saft.user = users.id WHERE semester='SS26' ORDER BY name \n\n"
+		}`), &collection); err != nil {
+			return err
+		}
+
+		// remove field
+		collection.Fields.RemoveById("_clone_zcVE")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_T6qp")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_KNIS")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_3ew0")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_B5Sw")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_FTFV")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_3AoX")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_4W96")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_0QUO")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_kgOy")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_IDDv")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_cLX3")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_feBt")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_ncd9")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_G3sr")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_I0tr")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_aXkm")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_GhM8")
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(0, []byte(`{
+			"hidden": false,
+			"id": "_clone_17g6",
+			"name": "created",
+			"onCreate": true,
+			"onUpdate": false,
+			"presentable": false,
+			"system": false,
+			"type": "autodate"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(2, []byte(`{
+			"hidden": false,
+			"id": "_clone_ZBKo",
+			"name": "paid",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "bool"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(7, []byte(`{
+			"hidden": false,
+			"id": "_clone_wouS",
+			"maxSelect": 1,
+			"name": "travel_option",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "select",
+			"values": [
+				"takesBike",
+				"takesTrain",
+				"takesCar",
+				"takesOwn",
+				"takesGroup"
+			]
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(8, []byte(`{
+			"autogeneratePattern": "",
+			"hidden": false,
+			"id": "_clone_dD2Z",
+			"max": 0,
+			"min": 0,
+			"name": "travel_comments",
+			"pattern": "",
+			"presentable": false,
+			"primaryKey": false,
+			"required": false,
+			"system": false,
+			"type": "text"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(9, []byte(`{
+			"hidden": false,
+			"id": "_clone_BI3d",
+			"maxSelect": 1,
+			"name": "group",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "select",
+			"values": [
+				"Karlsruhe",
+				"Landau"
+			]
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(10, []byte(`{
+			"autogeneratePattern": "",
+			"hidden": false,
+			"id": "_clone_uFCd",
+			"max": 0,
+			"min": 0,
+			"name": "ticket",
+			"pattern": "",
+			"presentable": false,
+			"primaryKey": false,
+			"required": false,
+			"system": false,
+			"type": "text"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(11, []byte(`{
+			"hidden": false,
+			"id": "_clone_scnD",
+			"name": "brings_cake",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "bool"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(14, []byte(`{
+			"hidden": false,
+			"id": "_clone_1Pce",
+			"name": "would_sleep_on_floor",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "bool"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(15, []byte(`{
+			"autogeneratePattern": "",
+			"hidden": false,
+			"id": "_clone_ocgj",
+			"max": 0,
+			"min": 0,
+			"name": "semester",
+			"pattern": "",
+			"presentable": false,
+			"primaryKey": false,
+			"required": false,
+			"system": false,
+			"type": "text"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(16, []byte(`{
+			"autogeneratePattern": "",
+			"hidden": false,
+			"id": "_clone_gnot",
+			"max": 0,
+			"min": 0,
+			"name": "comments",
+			"pattern": "",
+			"presentable": false,
+			"primaryKey": false,
+			"required": false,
+			"system": false,
+			"type": "text"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(17, []byte(`{
+			"hidden": false,
+			"id": "_clone_DJcR",
+			"maxSelect": 1,
+			"name": "post_images",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "select",
+			"values": [
+				"yes",
+				"no_instagram",
+				"no_website",
+				"no"
+			]
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(18, []byte(`{
+			"hidden": false,
+			"id": "_clone_k4He",
+			"name": "pot",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "bool"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(19, []byte(`{
+			"hidden": false,
+			"id": "_clone_ybga",
+			"name": "bag",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "bool"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(20, []byte(`{
+			"hidden": false,
+			"id": "_clone_ZxQe",
+			"max": null,
+			"min": null,
+			"name": "bag_count",
+			"onlyInt": false,
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "number"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(21, []byte(`{
+			"hidden": false,
+			"id": "_clone_3xFX",
+			"name": "pad",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "bool"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(22, []byte(`{
+			"hidden": false,
+			"id": "_clone_JDXk",
+			"max": null,
+			"min": null,
+			"name": "pad_count",
+			"onlyInt": false,
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "number"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(23, []byte(`{
+			"autogeneratePattern": "",
+			"hidden": false,
+			"id": "_clone_ZP7M",
+			"max": 0,
+			"min": 0,
+			"name": "tents",
+			"pattern": "",
+			"presentable": false,
+			"primaryKey": false,
+			"required": false,
+			"system": false,
+			"type": "text"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(24, []byte(`{
+			"hidden": false,
+			"id": "_clone_iQd0",
+			"name": "comes_friday",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "bool"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(25, []byte(`{
+			"autogeneratePattern": "",
+			"hidden": false,
+			"id": "_clone_RXhT",
+			"max": 0,
+			"min": 0,
+			"name": "side_dish",
+			"pattern": "",
+			"presentable": false,
+			"primaryKey": false,
+			"required": false,
+			"system": false,
+			"type": "text"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(26, []byte(`{
+			"hidden": false,
+			"id": "_clone_ggiv",
+			"name": "fairy_lights",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "bool"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(27, []byte(`{
+			"hidden": false,
+			"id": "_clone_O0xL",
+			"max": 5,
+			"min": 1,
+			"name": "likes_cooking",
+			"onlyInt": false,
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "number"
+		}`)); err != nil {
+			return err
+		}
+
+		return app.Save(collection)
+	}, func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("skzm3nv3gicpo9z")
+		if err != nil {
+			return err
+		}
+
+		// update collection data
+		if err := json.Unmarshal([]byte(`{
+			"viewQuery": "SELECT \n  saft.created,\n  saft.id as id,\n  saft.paid,\n  CAST(COALESCE((users.name || ' ' || users.surname), \n  (saft.name || ' ' || saft.surname)) AS TEXT) as name,\n  CAST(COALESCE(users.email, saft.email) AS TEXT) as email,\n  CAST(COALESCE(users.gender, saft.gender) AS TEXT) as gender,\n  CAST(COALESCE(users.phonenumber, saft.phonenumber) AS TEXT) as phonenumber,\n  saft.travel_option, saft.travel_comments, saft.[group],\n  saft.ticket, saft.brings_cake,\n  CAST(COALESCE(users.vegetarian, saft.is_vegetarian) AS BOOL) as is_vegetarian,\n  CAST(COALESCE(users.allergies, saft.allergies) AS TEXT) as allergies, \n  saft.would_sleep_on_floor, saft.semester, saft.comments, saft.post_images,\n  saft.pot, saft.bag, saft.bag_count, saft.pad, saft.pad_count, saft.tents, saft.comes_friday\n  from saft LEFT JOIN users on saft.user = users.id WHERE semester='SS26' ORDER BY name \n\n"
+		}`), &collection); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(0, []byte(`{
+			"hidden": false,
+			"id": "_clone_zcVE",
+			"name": "created",
+			"onCreate": true,
+			"onUpdate": false,
+			"presentable": false,
+			"system": false,
+			"type": "autodate"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(2, []byte(`{
+			"hidden": false,
+			"id": "_clone_T6qp",
+			"name": "paid",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "bool"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(7, []byte(`{
+			"hidden": false,
+			"id": "_clone_KNIS",
+			"maxSelect": 1,
+			"name": "travel_option",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "select",
+			"values": [
+				"takesBike",
+				"takesTrain",
+				"takesCar",
+				"takesOwn",
+				"takesGroup"
+			]
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(8, []byte(`{
+			"autogeneratePattern": "",
+			"hidden": false,
+			"id": "_clone_3ew0",
+			"max": 0,
+			"min": 0,
+			"name": "travel_comments",
+			"pattern": "",
+			"presentable": false,
+			"primaryKey": false,
+			"required": false,
+			"system": false,
+			"type": "text"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(9, []byte(`{
+			"hidden": false,
+			"id": "_clone_B5Sw",
+			"maxSelect": 1,
+			"name": "group",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "select",
+			"values": [
+				"Karlsruhe",
+				"Landau"
+			]
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(10, []byte(`{
+			"autogeneratePattern": "",
+			"hidden": false,
+			"id": "_clone_FTFV",
+			"max": 0,
+			"min": 0,
+			"name": "ticket",
+			"pattern": "",
+			"presentable": false,
+			"primaryKey": false,
+			"required": false,
+			"system": false,
+			"type": "text"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(11, []byte(`{
+			"hidden": false,
+			"id": "_clone_3AoX",
+			"name": "brings_cake",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "bool"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(14, []byte(`{
+			"hidden": false,
+			"id": "_clone_4W96",
+			"name": "would_sleep_on_floor",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "bool"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(15, []byte(`{
+			"autogeneratePattern": "",
+			"hidden": false,
+			"id": "_clone_0QUO",
+			"max": 0,
+			"min": 0,
+			"name": "semester",
+			"pattern": "",
+			"presentable": false,
+			"primaryKey": false,
+			"required": false,
+			"system": false,
+			"type": "text"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(16, []byte(`{
+			"autogeneratePattern": "",
+			"hidden": false,
+			"id": "_clone_kgOy",
+			"max": 0,
+			"min": 0,
+			"name": "comments",
+			"pattern": "",
+			"presentable": false,
+			"primaryKey": false,
+			"required": false,
+			"system": false,
+			"type": "text"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(17, []byte(`{
+			"hidden": false,
+			"id": "_clone_IDDv",
+			"maxSelect": 1,
+			"name": "post_images",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "select",
+			"values": [
+				"yes",
+				"no_instagram",
+				"no_website",
+				"no"
+			]
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(18, []byte(`{
+			"hidden": false,
+			"id": "_clone_cLX3",
+			"name": "pot",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "bool"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(19, []byte(`{
+			"hidden": false,
+			"id": "_clone_feBt",
+			"name": "bag",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "bool"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(20, []byte(`{
+			"hidden": false,
+			"id": "_clone_ncd9",
+			"max": null,
+			"min": null,
+			"name": "bag_count",
+			"onlyInt": false,
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "number"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(21, []byte(`{
+			"hidden": false,
+			"id": "_clone_G3sr",
+			"name": "pad",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "bool"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(22, []byte(`{
+			"hidden": false,
+			"id": "_clone_I0tr",
+			"max": null,
+			"min": null,
+			"name": "pad_count",
+			"onlyInt": false,
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "number"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(23, []byte(`{
+			"autogeneratePattern": "",
+			"hidden": false,
+			"id": "_clone_aXkm",
+			"max": 0,
+			"min": 0,
+			"name": "tents",
+			"pattern": "",
+			"presentable": false,
+			"primaryKey": false,
+			"required": false,
+			"system": false,
+			"type": "text"
+		}`)); err != nil {
+			return err
+		}
+
+		// add field
+		if err := collection.Fields.AddMarshaledJSONAt(24, []byte(`{
+			"hidden": false,
+			"id": "_clone_GhM8",
+			"name": "comes_friday",
+			"presentable": false,
+			"required": false,
+			"system": false,
+			"type": "bool"
+		}`)); err != nil {
+			return err
+		}
+
+		// remove field
+		collection.Fields.RemoveById("_clone_17g6")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_ZBKo")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_wouS")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_dD2Z")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_BI3d")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_uFCd")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_scnD")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_1Pce")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_ocgj")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_gnot")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_DJcR")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_k4He")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_ybga")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_ZxQe")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_3xFX")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_JDXk")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_ZP7M")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_iQd0")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_RXhT")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_ggiv")
+
+		// remove field
+		collection.Fields.RemoveById("_clone_O0xL")
+
+		return app.Save(collection)
+	})
+}

--- a/frontend/src/routes/intern/saft/list/+page.svelte
+++ b/frontend/src/routes/intern/saft/list/+page.svelte
@@ -212,7 +212,8 @@
 
 		<div class="flex overflow-auto">
 			<div
-				class="pad-childs grid grid-cols-[repeat(25,1fr)] divide-y-2 divide-y-reverse divide-x-reverse whitespace-nowrap"
+				class="pad-childs grid divide-y-2 divide-y-reverse divide-x-reverse whitespace-nowrap"
+				style={`grid-template-columns: repeat(${columns.length}, 1fr);`}
 			>
 				{#each columns as column}
 					<div><b>{column}</b></div>

--- a/frontend/src/routes/intern/saft/list/+page.svelte
+++ b/frontend/src/routes/intern/saft/list/+page.svelte
@@ -141,6 +141,7 @@
 					<b>{data.availableBags}</b> verfügbare Schlafsäcke <br />
 					<b>{data.sleepingPadsMissing}</b> Personen, die ne Iso brauchen <br />
 					<b>{data.availablePads}</b> verfügbare Isomatten <br />
+					<b>{data.fairyLightsCount}</b> Lichterketten <br />
 				</div>
 			</div>
 			<div>
@@ -151,10 +152,6 @@
 				<div>
 					<bold class="font-bold">{data.isMale}</bold>
 					Anzahl Männer
-				</div>
-				<div>
-					<bold class="font-bold">{data.fairyLightsCount}</bold>
-					Lichterketten
 				</div>
 			</div>
 

--- a/frontend/src/routes/intern/saft/list/+page.svelte
+++ b/frontend/src/routes/intern/saft/list/+page.svelte
@@ -68,13 +68,16 @@
 		'Bemerkung',
 		'E-Mail-Adresse',
 		'Telefonnummer',
-		// SS25
+		// summer semester outdoor
 		'Schlafsack',
 		'Isomatte',
 		'Gaskocher mit Topf',
 		'Zelte',
 		'Anzahl Schlafsäcke zu verleihen',
 		'Anzahl Isomatten zu verleihen',
+		'Beilage zum Grillen',
+		'Lichterkette',
+		'Kochen (1-5)',
 		//
 		'Kuchen',
 		'Vegetarier',
@@ -149,6 +152,10 @@
 					<bold class="font-bold">{data.isMale}</bold>
 					Anzahl Männer
 				</div>
+				<div>
+					<bold class="font-bold">{data.fairyLightsCount}</bold>
+					Lichterketten
+				</div>
 			</div>
 
 			<!-- nochmal block mit Gender -->
@@ -208,7 +215,7 @@
 
 		<div class="flex overflow-auto">
 			<div
-				class="pad-childs grid grid-cols-[repeat(22,1fr)] divide-y-2 divide-y-reverse divide-x-reverse whitespace-nowrap"
+				class="pad-childs grid grid-cols-[repeat(25,1fr)] divide-y-2 divide-y-reverse divide-x-reverse whitespace-nowrap"
 			>
 				{#each columns as column}
 					<div><b>{column}</b></div>
@@ -263,6 +270,9 @@
 					<div>{registration.tents}</div>
 					<div>{registration.bag_count}</div>
 					<div>{registration.pad_count}</div>
+					<div class="w-60 whitespace-pre-wrap">{registration.side_dish}</div>
+					<div>{registration.fairy_lights ? 'Ja' : ''}</div>
+					<div>{registration.likes_cooking ?? ''}</div>
 
 					<div>{registration.brings_cake ? 'Ja' : ''}</div>
 					<div>{registration.is_vegetarian ? 'Ja' : ''}</div>

--- a/frontend/src/routes/intern/saft/list/+page.svelte
+++ b/frontend/src/routes/intern/saft/list/+page.svelte
@@ -169,7 +169,7 @@
 				Email an den Verteiler senden</a
 			>
 			<button
-				class="bg-light-blue flex items-center gap-2 rounded-md px-4 py-2"
+				class="flex items-center gap-2 rounded-md bg-light-blue px-4 py-2"
 				on:click={() =>
 					navigator.clipboard.writeText(
 						filteredList
@@ -183,7 +183,7 @@
 			</button>
 
 			<button
-				class="bg-lime flex items-center gap-2 rounded-md px-4 py-2"
+				class="flex items-center gap-2 rounded-md bg-lime px-4 py-2"
 				on:click|preventDefault={() => _exportToCsv(filteredList, filter)}
 			>
 				<Fa icon={faArrowUpFromBracket} />

--- a/frontend/src/routes/intern/saft/list/+page.ts
+++ b/frontend/src/routes/intern/saft/list/+page.ts
@@ -44,6 +44,7 @@ export const load: PageLoad = async () => {
 		const sleepingPadsMissing = records.filter((x) => !x.pad).length;
 		const availableBags = records.reduce((sum, x) => sum + x.bag_count, 0);
 		const availablePads = records.reduce((sum, x) => sum + x.pad_count, 0);
+		const fairyLightsCount = records.filter((x) => x.fairy_lights).length;
 
 		const lastSubmission = records.map((x) => x.created).reduce((prev, cur) => (prev > cur) ? prev : cur);
 
@@ -66,6 +67,7 @@ export const load: PageLoad = async () => {
 			availablePads,
 			isFemale,
 			isMale,
+			fairyLightsCount,
 			lastSubmission,
 		};
 	} catch (error) {
@@ -129,7 +131,10 @@ export const _exportToCsv = (list, filter) => {
 			'Gaskocher mit Topf',
 			'Zelte',
 			'Anzahl Schlafsäcke zu verleihen',
-			'Anzahl Isomatten zu verleihen'
+			'Anzahl Isomatten zu verleihen',
+			'Beilage zum Grillen',
+			'Lichterkette',
+			'Kochen (1-5)'
 		],
 		...list.map((x) => [
 			x.created,
@@ -155,7 +160,10 @@ export const _exportToCsv = (list, filter) => {
 			x.pot ? 'Ja' : '',
 			x.tents,
 			x.bag_count,
-			x.pad_count
+			x.pad_count,
+			escapeCsv(x.side_dish ?? ''),
+			x.fairy_lights ? 'Ja' : '',
+			x.likes_cooking ?? ''
 		])
 	];
 

--- a/frontend/src/routes/intern/saft/list/+page.ts
+++ b/frontend/src/routes/intern/saft/list/+page.ts
@@ -37,7 +37,7 @@ export const load: PageLoad = async () => {
 		const hasKVVCount = records.filter((x) => x.ticket === 'KVV-Bescheinigung').length;
 		const hasKVVSemesterCount = records.filter((x) => x.ticket === 'KVV-Semesterticket').length;
 
-		// SS25
+		// ZELT-SAFT
 		const comesFridayCount = records.filter((x) => x.comes_friday).length;
 		const pots = records.filter((x) => x.pot).length;
 		const sleepingBagsMissing = records.filter((x) => !x.bag).length;
@@ -124,7 +124,7 @@ export const _exportToCsv = (list, filter) => {
 			'Vegetarier',
 			'Allergien',
 			'Bildrechte',
-			// SS25
+			// ZELT-SAFT
 			'Anreise Freitag',
 			'Schlafsack',
 			'Isomatte',
@@ -153,7 +153,7 @@ export const _exportToCsv = (list, filter) => {
 			x.is_vegetarian ? 'Ja' : '',
 			escapeCsv(x.allergies),
 			_postImages(x.post_images),
-			// SS25
+			// ZELT-SAFT
 			x.comes_friday ? 'Ja' : '',
 			x.bag ? 'Ja' : '',
 			x.pad ? 'Ja' : '',

--- a/frontend/src/routes/saft/signup/form/+page.svelte
+++ b/frontend/src/routes/saft/signup/form/+page.svelte
@@ -69,7 +69,7 @@
 		);
 		formData.set('brings_cake', formData.get('brings_cake') === 'on' ? 'true' : 'false');
 		formData.set('is_vegetarian', formData.get('is_vegetarian') === 'on' ? 'true' : 'false');
-		// SS25
+		// ZELT-SAFT
 		formData.set('comes_friday', formData.get('comes_friday') === 'on' ? 'true' : 'false');
 		formData.set('pot', formData.get('pot') === 'on' ? 'true' : 'false');
 		formData.set('bag', formData.get('bag') === 'on' ? 'true' : 'false');
@@ -293,7 +293,7 @@
 					{/if}
 
 					<div class="flex flex-col">
-						<!-- +++ SS25 +++
+						<!-- +++ ZELT-SAFT +++
 					<InputCheckbox name="comes_friday" label="Anreise am Freitag"></InputCheckbox>
 					-->
 						<label for="travel_comments">


### PR DESCRIPTION
This pull request updates the SAFT list page to add new data columns and improve the display and export functionality for registration details. The main changes include adding fields for side dishes, fairy lights, and cooking preferences, updating the UI to show these new fields, and ensuring that CSV exports include the new data.

**Feature additions:**

* Added new columns to the registration table and CSV export: 'Beilage zum Grillen' (side dish), 'Lichterkette' (fairy lights), and 'Kochen (1-5)' (cooking preference). These are now included in both the table UI and CSV output. [[1]](diffhunk://#diff-0cbe9ed897c5fbdf564a542e41a0f24ba86abde46685a520d121a12a4c603509L71-R80) [[2]](diffhunk://#diff-82dbe30c3a1f818fbc25b2b6f79844377f3a23ecb23e6a7175abc5dbad1a8ad1L132-R137) [[3]](diffhunk://#diff-82dbe30c3a1f818fbc25b2b6f79844377f3a23ecb23e6a7175abc5dbad1a8ad1L158-R166) [[4]](diffhunk://#diff-0cbe9ed897c5fbdf564a542e41a0f24ba86abde46685a520d121a12a4c603509R273-R275)
* Updated the grid layout in the table to accommodate the new columns, increasing the column count from 22 to 25.

**UI improvements:**

* Added a display for the total count of fairy lights (`fairyLightsCount`) in the summary section. [[1]](diffhunk://#diff-82dbe30c3a1f818fbc25b2b6f79844377f3a23ecb23e6a7175abc5dbad1a8ad1R47) [[2]](diffhunk://#diff-82dbe30c3a1f818fbc25b2b6f79844377f3a23ecb23e6a7175abc5dbad1a8ad1R70) [[3]](diffhunk://#diff-0cbe9ed897c5fbdf564a542e41a0f24ba86abde46685a520d121a12a4c603509R155-R158)
* Minor improvements to button class order for consistency. [[1]](diffhunk://#diff-0cbe9ed897c5fbdf564a542e41a0f24ba86abde46685a520d121a12a4c603509L172-R179) [[2]](diffhunk://#diff-0cbe9ed897c5fbdf564a542e41a0f24ba86abde46685a520d121a12a4c603509L186-R193)