### PR TITLE
SAFT Signup Bot Protection lite

### DIFF
--- a/backend/saft/saft.go
+++ b/backend/saft/saft.go
@@ -5,7 +5,6 @@ import (
 	"net/mail"
 	"strings"
 
-	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/apis"
 	"github.com/pocketbase/pocketbase/core"
@@ -49,7 +48,7 @@ func SaftEmails(app *pocketbase.PocketBase) {
 		if user_id != "" {
 			// verifies that user is authenticated
 			// and copies user data for the registration
-			err = copyUserDataToRecord(app, user_id, e)
+			err = copyUserDataToRecord(user_id, e)
 		} else {
 			// otherwise validate that bot question was answered correctly
 			err = validateCaptchaLite(e)
@@ -108,43 +107,30 @@ func validateBotQuestion(answer string) bool {
 	return b.String() == BotQuestionExpected
 }
 
-// is expected to fail when userId is invalid
-// but not, when userId was just unset
-// TODO (security) verify that the user with that id was authenticated during the request
-func copyUserDataToRecord(app *pocketbase.PocketBase, userId string, e *core.RecordRequestEvent) error {
-	if userId == "" {
-		return nil
-	}
-
-	// Define how the output of the query below looks like
-	type User struct {
-		Id           string `db:"id" json:"id"`
-		Name         string `db:"name" json:"name"`
-		Surname      string `db:"surname" json:"surname"`
-		Email        string `db:"email" json:"email"`
-		Gender       string `db:"gender" json:"gender"`
-		PhoneNumber  string `db:"phonenumber" json:"phonenumber"`
-		Allergies    string `db:"allergies" json:"allergies"`
-		IsVegetarian bool   `db:"vegetarian" json:"vegetarian"`
-	}
-
-	// Create empty user
-	user := User{}
-
-	err := app.DB().Select("id", "name", "email", "surname", "allergies", "vegetarian", "phonenumber", "gender").From("users").AndWhere(dbx.HashExp{"id": userId}).One(&user)
-	// when looking up that user fails, forward error
+func copyUserDataToRecord(user_id string, e *core.RecordRequestEvent) error {
+	// load user data from currently signed in user
+	reqInfo, err := e.RequestInfo()
 	if err != nil {
 		return err
 	}
+	user := reqInfo.Auth
+	if user == nil {
+		return apis.NewUnauthorizedError("must be authenticated", nil)
+	}
 
-	// Set user data to record for template
-	e.Record.Set("name", user.Name)
-	e.Record.Set("surname", user.Surname)
-	e.Record.Set("email", user.Email)
-	e.Record.Set("allergies", user.Allergies)
-	e.Record.Set("is_vegetarian", user.IsVegetarian)
-	e.Record.Set("phonenumber", user.PhoneNumber)
-	e.Record.Set("gender", user.Gender)
+	// verify that the same user is mentioned (because that gets saved to the db)
+	if user.Id != user_id {
+		return apis.NewUnauthorizedError("must be authenticated", nil)
+	}
+
+	// copy user data to record
+	e.Record.Set("name", user.GetString("name"))
+	e.Record.Set("surname", user.GetString("surname"))
+	e.Record.Set("email", user.GetString("email"))
+	e.Record.Set("allergies", user.GetString("allergies"))
+	e.Record.Set("is_vegetarian", user.GetBool("vegetarian"))
+	e.Record.Set("phonenumber", user.GetString("phonenumber"))
+	e.Record.Set("gender", user.GetString("gender"))
 
 	return nil
 }

--- a/backend/saft/saft.go
+++ b/backend/saft/saft.go
@@ -30,7 +30,8 @@ func SaftEmails(app *pocketbase.PocketBase) {
 		return se.Next()
 	})
 
-	app.OnRecordCreate("saft").BindFunc(func(e *core.RecordEvent) error {
+	// only triggers on external API requests
+	app.OnRecordCreateRequest("saft").BindFunc(func(e *core.RecordRequestEvent) error {
 
 		// SAFT registration open?
 		semester := e.Record.GetString("semester")
@@ -63,7 +64,7 @@ func SaftEmails(app *pocketbase.PocketBase) {
 	})
 }
 
-func copyUserDataToRecord(app *pocketbase.PocketBase, userId string, e *core.RecordEvent) error {
+func copyUserDataToRecord(app *pocketbase.PocketBase, userId string, e *core.RecordRequestEvent) error {
 	if userId == "" {
 		return nil
 	}
@@ -101,7 +102,7 @@ func copyUserDataToRecord(app *pocketbase.PocketBase, userId string, e *core.Rec
 	return nil
 }
 
-func sendSAFTConfirmationEmail(app *pocketbase.PocketBase, e *core.RecordEvent) error {
+func sendSAFTConfirmationEmail(app *pocketbase.PocketBase, e *core.RecordRequestEvent) error {
 
 	registry := template.NewRegistry()
 

--- a/backend/saft/saft.go
+++ b/backend/saft/saft.go
@@ -3,6 +3,7 @@ package saft
 import (
 	"net/http"
 	"net/mail"
+	"strings"
 
 	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase"
@@ -15,10 +16,13 @@ import (
 	"SMD-KA-Backend/saft/regStatus"
 )
 
-// Constants for SAFT registration emails
 const (
+	// Constants for SAFT registration emails
 	Subject   = "[SMD-KA] SAFT Anmeldung "
 	OrgaEmail = "inreach@smd-karlsruhe.de"
+
+	// checked against lowercase, without any characters outside [a-z]
+	BotQuestionExpected = "abendmahl"
 )
 
 func SaftEmails(app *pocketbase.PocketBase) {
@@ -41,7 +45,15 @@ func SaftEmails(app *pocketbase.PocketBase) {
 
 		// Submission by user?
 		user_id := e.Record.GetString("user")
-		err := copyUserDataToRecord(app, user_id, e)
+		var err error
+		if user_id != "" {
+			// verifies that user is authenticated
+			// and copies user data for the registration
+			err = copyUserDataToRecord(app, user_id, e)
+		} else {
+			// otherwise validate that bot question was answered correctly
+			err = validateCaptchaLite(e)
+		}
 		if err != nil {
 			return err
 		}
@@ -64,6 +76,41 @@ func SaftEmails(app *pocketbase.PocketBase) {
 	})
 }
 
+func validateCaptchaLite(e *core.RecordRequestEvent) error {
+	botData := struct {
+		Answer string `json:"bot_question" form:"bot_question"`
+	}{}
+	err := e.BindBody(&botData)
+	if err == nil && validateBotQuestion(botData.Answer) {
+		return nil
+	}
+	// when that fails as well, show unauthenticated error
+	// -> diverting bots & users from the fact, that a 'field' was missing
+	return apis.NewUnauthorizedError("must be authenticated", nil)
+}
+
+// returns true when answer is as expected
+// after toLower & removing all runes that are not in a-z
+func validateBotQuestion(answer string) bool {
+	expLen := len(BotQuestionExpected)
+	actLen := len(answer)
+	// also reject, when answer is way too long to be realistic
+	if expLen > actLen || actLen > (2*expLen) {
+		return false
+	}
+	var b strings.Builder
+	b.Grow(actLen)
+	for _, r := range strings.ToLower(answer) {
+		if r >= 'a' && r <= 'z' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String() == BotQuestionExpected
+}
+
+// is expected to fail when userId is invalid
+// but not, when userId was just unset
+// TODO (security) verify that the user with that id was authenticated during the request
 func copyUserDataToRecord(app *pocketbase.PocketBase, userId string, e *core.RecordRequestEvent) error {
 	if userId == "" {
 		return nil

--- a/frontend/src/routes/saft/signup/form/+page.svelte
+++ b/frontend/src/routes/saft/signup/form/+page.svelte
@@ -339,17 +339,28 @@
 						<textarea class="rounded-md border-2" name="comments" id="comments" rows="5"></textarea>
 					</div>
 
-					<button
-						disabled={loading}
-						class="relative flex items-center justify-center bg-black px-12 py-4 text-white md:w-fit"
-					>
-						{#if loading}
-							<img class="absolute left-2 h-8" src={loadingSpinnerWhite} alt="loading" />
-						{/if}
-						Anmelden
-					</button>
+					<div class="button-row">
+						<button type="submit" disabled={loading}>
+							{#if loading}
+								<img class="absolute left-2 h-8" src={loadingSpinnerWhite} alt="loading" />
+							{/if}
+							Anmelden
+						</button>
+					</div>
 				</form>
 			{/if}
 		{/if}
 	</div>
 </main>
+
+<style>
+	.button-row {
+		@apply flex flex-row flex-wrap gap-8;
+	}
+	.button-row button {
+		@apply px-12 py-4;
+	}
+	button {
+		@apply relative flex items-center justify-center bg-black px-4 py-2 text-white md:w-fit;
+	}
+</style>

--- a/frontend/src/routes/saft/signup/form/+page.svelte
+++ b/frontend/src/routes/saft/signup/form/+page.svelte
@@ -5,6 +5,7 @@
 	import InputCheckbox from '$lib/components/forms/CheckboxInput.svelte';
 	import { getErrorMessage, pb } from '$lib/pocketbase';
 	import { onMount } from 'svelte';
+	import { dev } from '$app/environment';
 	import type { saftRegistration } from '$lib/models';
 	import EmailInputField from '$lib/components/forms/EmailInput.svelte';
 	import TelephoneInputField from '$lib/components/forms/TelephoneInputField.svelte';
@@ -22,6 +23,7 @@
 	import MessageClosed from '../../_components/MessageClosed.svelte';
 
 	import { RegistrationStatus, requestRegStatus } from '$lib/saftRegistrationApi';
+	import { fillSaftFormTest } from './testFiller';
 
 	const ticketValues = [
 		'Deutschlandticket/Jugendticket BW',
@@ -120,6 +122,11 @@
 					noch einmal.
 				</p>
 			{:else}
+				{#if dev}
+					<button type="button" disabled={loading} on:click={() => fillSaftFormTest(loggedIn)}>
+						Testdaten einfügen
+					</button>
+				{/if}
 				{#if loggedIn}
 					<p class="py-6 text-xl text-primary">
 						Schön, dass du dabei bist {pb.authStore.model?.name}!
@@ -340,6 +347,11 @@
 					</div>
 
 					<div class="button-row">
+						{#if dev}
+							<button type="button" disabled={loading} on:click={() => fillSaftFormTest(loggedIn)}>
+								Testdaten einfügen
+							</button>
+						{/if}
 						<button type="submit" disabled={loading}>
 							{#if loading}
 								<img class="absolute left-2 h-8" src={loadingSpinnerWhite} alt="loading" />

--- a/frontend/src/routes/saft/signup/form/+page.svelte
+++ b/frontend/src/routes/saft/signup/form/+page.svelte
@@ -44,6 +44,7 @@
 	let regStatus: RegistrationStatus = RegistrationStatus.Unknown;
 	$: loading = status == FormStatus.Submitting;
 	$: success = status == FormStatus.SuccessfullySubmit;
+	$: errorOnSubmit = status == FormStatus.ErrorOnSubmit;
 
 	let record: saftRegistration;
 	let loggedIn = false;
@@ -357,6 +358,20 @@
 								required
 							/>
 						</div>
+					{/if}
+
+					{#if errorOnSubmit}
+						<p class="text-red-600">
+							Beim Anmelden trat ein Fehler auf.
+							{#if !loggedIn}
+								Prüfe bitte, ob deine Antwort auf die letzte Frage richtig (geschrieben) ist ;).
+								<!-- change start of next sentence -->
+								Sonst lade bitte
+							{:else}
+								Bitte lade
+							{/if}
+							die Seite neu oder probiere es später erneut.
+						</p>
 					{/if}
 
 					<div class="button-row">

--- a/frontend/src/routes/saft/signup/form/+page.svelte
+++ b/frontend/src/routes/saft/signup/form/+page.svelte
@@ -346,6 +346,19 @@
 						<textarea class="rounded-md border-2" name="comments" id="comments" rows="5"></textarea>
 					</div>
 
+					{#if !loggedIn}
+						<div class="flex flex-col">
+							<p>Bei was teilen wir Brot &amp; Wein?</p>
+							<InputField
+								id="bot_question"
+								name="bot_question"
+								label="Das …"
+								disabled={loading}
+								required
+							/>
+						</div>
+					{/if}
+
 					<div class="button-row">
 						{#if dev}
 							<button type="button" disabled={loading} on:click={() => fillSaftFormTest(loggedIn)}>

--- a/frontend/src/routes/saft/signup/form/testFiller.ts
+++ b/frontend/src/routes/saft/signup/form/testFiller.ts
@@ -1,0 +1,49 @@
+// should only be used by admins for testing the SAFT signup form
+// i.e. alerts on failures is good enough
+export function fillSaftFormTest(isLoggedIn: boolean) {
+	const form = document.querySelector('form#form');
+	if (!form) return alert("saft form not found");
+
+	const setValue = (name: string, value: string) => {
+		const el = form.querySelector(`[name="${CSS.escape(name)}"]`) as HTMLInputElement;
+		if (!el) return alert(`input ${name} not found`);
+
+		el.value = value;
+		return true;
+	};
+
+	const checkRadio = (name: string, value: string) => {
+		const el = form.querySelector(
+			`input[type="radio"][name="${CSS.escape(name)}"][value="${CSS.escape(value)}"]`
+		) as HTMLInputElement;
+		if (!el) return alert(`radio ${value} for ${name} not found`);
+
+		el.click();
+		return true;
+	};
+
+	const coinToss = Math.random() < 0.5
+
+	// Only exists for logged-out users (conditional block in +page.svelte)
+	if (!isLoggedIn) {
+		setValue('name', 'Test');
+		setValue('surname', 'User');
+		// @example so that no MX record exists -> no mail can be sent
+		setValue('email', 'test@example');
+		// see https://www.bundesnetzagentur.de/DE/Fachthemen/Telekommunikation/Nummerierung/_DL/mittlg148_2021.pdf?__blob=publicationFile&v=1
+		setValue('phonenumber', '+491729973185');
+		checkRadio("gender", coinToss ? "male" : "female")
+	}
+
+	// Required: travel_option (also controls whether ticket radios render)
+	setValue('travel_option', 'takesOwn');
+
+	// Required: likes_cooking (1..5)
+	checkRadio('likes_cooking', '3');
+
+	// Required: post_images select
+	setValue('post_images', 'no');
+
+	// just in case
+	setValue('comments', 'TEST-DATEN, bitte ignorieren & einfach löschen');
+}


### PR DESCRIPTION
Implemented by requiring users to answer one simple, contextual question.

Verification of answer is not hard, because the user-submitted value will first be lowercased, then all characters outside "a-z" will be removed to avoid any kind of whitespace issues. The answer is also rejected before filtering if it is deemed too long (currently twice the length of the expected answer) to avoid overloading issues on that side.

Also applied following changes to the signup form:
- show error message when submission fails (with hint to that last question)
- backend: verify user_id & copy from currently authenticated user
- (for dev only) add button for inserting test data to form